### PR TITLE
Bugfix: make `serialize_arg/1` support valid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 <!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
+## [Unreleased]
+### Fixed
+
+- Serialization of args given to `PlaywrightEx.Frame.evaluate/2`
+
 ## [0.2.1] 2025-11-28
 ### Changed
 - Suppress node.js errors on termination

--- a/test/playwright_ex/periphery/serialization_test.exs
+++ b/test/playwright_ex/periphery/serialization_test.exs
@@ -1,0 +1,74 @@
+defmodule PlaywrightEx.SerializationTest do
+  use ExUnit.Case, async: true
+
+  alias PlaywrightEx.Serialization
+
+  describe "serialize_arg/1" do
+    test "returns expected structure with handles" do
+      result = Serialization.serialize_arg("test")
+
+      assert %{value: _, handles: []} = result
+    end
+  end
+
+  describe "serialize_arg/1 and deserialize_arg/1 round-trip" do
+    @test_values [
+      nil,
+      true,
+      false,
+      0,
+      42,
+      -17,
+      3.14,
+      -2.5,
+      "",
+      "hello",
+      "hello world",
+      "with \"quotes\" and 'apostrophes'",
+      "unicode: ὁ χριστός",
+      [],
+      [1, 2, 3],
+      ["a", "b", "c"],
+      [true, false, nil],
+      [1, "two", 3.0, nil, true],
+      [[1, 2], [3, 4]],
+      %{},
+      %{"key" => "value"},
+      %{"a" => 1, "b" => 2},
+      %{"nested" => %{"deep" => "value"}},
+      %{"mixed" => [1, "two", %{"three" => 3}]},
+      %{"bool" => true, "nil" => nil, "num" => 42, "str" => "hello"}
+    ]
+
+    for value <- @test_values do
+      test "round-trips #{inspect(value)}" do
+        value = unquote(Macro.escape(value))
+
+        serialized = Serialization.serialize_arg(value)
+        deserialized = Serialization.deserialize_arg(serialized.value)
+
+        assert deserialized == value
+      end
+    end
+
+    test "converts atoms to strings" do
+      value = :some_atom
+
+      serialized = Serialization.serialize_arg(value)
+      deserialized = Serialization.deserialize_arg(serialized.value)
+
+      # Atoms become strings after round-trip
+      assert deserialized == "some_atom"
+    end
+
+    test "converts atom keys to string keys in maps" do
+      value = %{foo: "bar", baz: 123}
+
+      serialized = Serialization.serialize_arg(value)
+      deserialized = Serialization.deserialize_arg(serialized.value)
+
+      # Atom keys become string keys after round-trip
+      assert deserialized == %{"foo" => "bar", "baz" => 123}
+    end
+  end
+end


### PR DESCRIPTION
`PlaywrightEx.Frame.evaluate/2` previously could not accept args other than `nil`.

With this change, we can pass a map of arguments to JavaScript like this:

```elixir
def scroll_to_selector(frame_id, selector) do
  PlaywrightEx.Frame.evaluate(
    frame_id,
    expression: """
    (my_scroll_target) => {
    const el = document.querySelector(my_scroll_target);
    if (!el) throw new Error('Element not found');
    el.scrollIntoView({ behavior: 'instant', block: 'center' });
    }
    """,
    is_function: true,
    arg: %{my_scroll_target: selector},
    timeout: 5000
  )
end
```

...instead of having to build the complete code snippet in Elixir:

```elixir
def scroll_to_selector(frame_id, selector) do
  PlaywrightEx.Frame.evaluate(
    frame_id,
    expression: """
    () => {
    const el = document.querySelector(#{Jason.encode!(selector)});
    if (!el) throw new Error('Element not found');
    el.scrollIntoView({ behavior: 'instant', block: 'center' });
    }
    """,
    is_function: true,
    timeout: 5000
  )
end
```