### PR TITLE
Add `BrowserContext.add_init_script/2` And `Page.add_init_script/2`

### DIFF
--- a/lib/playwright_ex/channels/browser_context.ex
+++ b/lib/playwright_ex/channels/browser_context.ex
@@ -221,6 +221,7 @@ defmodule PlaywrightEx.BrowserContext do
 
   schema =
     NimbleOptions.new!(
+      connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
       content: [
         type: :string,
@@ -254,10 +255,11 @@ defmodule PlaywrightEx.BrowserContext do
   @spec add_init_script(PlaywrightEx.guid(), [add_init_script_opt() | PlaywrightEx.unknown_opt()]) ::
           {:ok, any()} | {:error, any()}
   def add_init_script(context_id, opts \\ []) do
-    {timeout, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:timeout)
+    {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
+    {timeout, opts} = Keyword.pop!(opts, :timeout)
 
-    %{guid: context_id, method: :addInitScript, params: Map.new(opts)}
-    |> Connection.send(timeout)
+    connection
+    |> Connection.send(%{guid: context_id, method: :addInitScript, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
 end

--- a/lib/playwright_ex/channels/page.ex
+++ b/lib/playwright_ex/channels/page.ex
@@ -212,6 +212,7 @@ defmodule PlaywrightEx.Page do
 
   schema =
     NimbleOptions.new!(
+      connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
       content: [
         type: :string,
@@ -245,10 +246,11 @@ defmodule PlaywrightEx.Page do
   @spec add_init_script(PlaywrightEx.guid(), [add_init_script_opt() | PlaywrightEx.unknown_opt()]) ::
           {:ok, any()} | {:error, any()}
   def add_init_script(context_id, opts \\ []) do
-    {timeout, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:timeout)
+    {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
+    {timeout, opts} = Keyword.pop!(opts, :timeout)
 
-    %{guid: context_id, method: :addInitScript, params: Map.new(opts)}
-    |> Connection.send(timeout)
+    connection
+    |> Connection.send(%{guid: context_id, method: :addInitScript, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
 end


### PR DESCRIPTION
Playwright has the functionality to add an init script into Browser Contexts and Pages to ensure that scripts are run before anything else on the page is run. This PR adds the two functions to the relevant channels.