### PR TITLE
Add Page.bring_to_front/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `PlaywrightEx.Page.expect_url/2` for explicit URL expectations on pages.
 - Regex support in argument serialization/deserialization using protocol-native `{r: %{p, f}}` values.
 - `PlaywrightEx.Page.reload/2` to reload current page.
+- `PlaywrightEx.Page.bring_to_front/2` to activate a page tab. #29
 ### Fixed
 - `PlaywrightEx.Frame.wait_for_selector/2`: crash when `state` is `"hidden"` or `"detached"` (result has no element). #22
 - `PlaywrightEx.BrowserContext.add_init_script/2` and `PlaywrightEx.Page.add_init_script/2`: use `source` parameter name required by Playwright protocol (instead of `content`).

--- a/lib/playwright_ex/channels/page.ex
+++ b/lib/playwright_ex/channels/page.ex
@@ -77,6 +77,35 @@ defmodule PlaywrightEx.Page do
   schema =
     NimbleOptions.new!(
       connection: PlaywrightEx.Channel.connection_opt(),
+      timeout: PlaywrightEx.Channel.timeout_opt()
+    )
+
+  @doc """
+  Brings page to front (activates tab).
+
+  Reference: https://playwright.dev/docs/api/class-page#page-bring-to-front
+
+  ## Options
+  #{NimbleOptions.docs(schema)}
+  """
+  @schema schema
+  @type bring_to_front_opt :: unquote(NimbleOptions.option_typespec(schema))
+  @spec bring_to_front(PlaywrightEx.guid(), [bring_to_front_opt() | PlaywrightEx.unknown_opt()]) ::
+          {:ok, any()} | {:error, any()}
+  def bring_to_front(page_id, opts \\ []) do
+    {connection, opts} =
+      opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
+
+    {timeout, opts} = Keyword.pop!(opts, :timeout)
+
+    connection
+    |> Connection.send(%{guid: page_id, method: :bring_to_front, params: Map.new(opts)}, timeout)
+    |> ChannelResponse.unwrap(& &1)
+  end
+
+  schema =
+    NimbleOptions.new!(
+      connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
       full_page: [
         type: :boolean,

--- a/test/playwright_ex/page_test.exs
+++ b/test/playwright_ex/page_test.exs
@@ -1,8 +1,21 @@
 defmodule PlaywrightEx.PageTest do
   use PlaywrightExCase, async: true
 
+  alias PlaywrightEx.BrowserContext
   alias PlaywrightEx.Frame
   alias PlaywrightEx.Page
+
+  describe "bring_to_front/2" do
+    test "activates pages without protocol errors", %{browser_context: browser_context, page: page} do
+      {:ok, second_page} = BrowserContext.new_page(browser_context.guid, timeout: @timeout)
+
+      assert {:ok, _} = Frame.goto(page.main_frame.guid, url: "about:blank", timeout: @timeout)
+      assert {:ok, _} = Frame.goto(second_page.main_frame.guid, url: "about:blank", timeout: @timeout)
+
+      assert {:ok, _} = Page.bring_to_front(page.guid, timeout: @timeout)
+      assert {:ok, _} = Page.bring_to_front(second_page.guid, timeout: @timeout)
+    end
+  end
 
   describe "add_init_script/2" do
     test "applies script on navigation", %{page: page, frame: frame} do


### PR DESCRIPTION
Add `PlaywrightEx.Page.bring_to_front/2` as a thin wrapper over Playwright's `bringToFront` page channel method.

Closes #29
