### PR TITLE
Allow passing an `:env` option to set the environment on the Port transport

### DIFF
--- a/lib/playwright_ex/processes/port_transport.ex
+++ b/lib/playwright_ex/processes/port_transport.ex
@@ -49,13 +49,8 @@ defmodule PlaywrightEx.PortTransport do
   end
 
   def init(%{executable: executable, env: env} = opts) when map_size(env) > 0 do
-    env =
-      env
-      |> Map.new(fn {k, v} -> {maybe_charlist(k), maybe_charlist(v)} end)
-      |> Enum.to_list()
-
+    env = Enum.map(env, fn {k, v} -> {maybe_charlist(k), maybe_charlist(v)} end)
     port = Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, {:args, ["run-driver"]}, {:env, env}])
-
     connection_name = Map.get(opts, :connection_name, Connection)
     {:ok, %__MODULE__{port: port, connection_name: connection_name}}
   end

--- a/lib/playwright_ex/processes/port_transport.ex
+++ b/lib/playwright_ex/processes/port_transport.ex
@@ -31,7 +31,7 @@ defmodule PlaywrightEx.PortTransport do
   Start the PortTransport and link it to the connection process.
   """
   def start_link(opts) do
-    opts = Keyword.validate!(opts, [:executable, :name, :connection_name])
+    opts = Keyword.validate!(opts, [:executable, :name, :connection_name, :env])
     name = Keyword.get(opts, :name, @default_name)
     GenServer.start_link(__MODULE__, Map.new(opts), name: name)
   end
@@ -42,8 +42,20 @@ defmodule PlaywrightEx.PortTransport do
   end
 
   @impl GenServer
-  def init(%{executable: executable} = opts) do
+  def init(%{executable: executable, env: env} = opts) when map_size(env) == 0 do
     port = Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, args: ["run-driver"]])
+    connection_name = Map.get(opts, :connection_name, Connection)
+    {:ok, %__MODULE__{port: port, connection_name: connection_name}}
+  end
+
+  def init(%{executable: executable, env: env} = opts) when map_size(env) > 0 do
+    env =
+      env
+      |> Map.new(fn {k, v} -> {maybe_charlist(k), maybe_charlist(v)} end)
+      |> Enum.to_list()
+
+    port = Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, {:args, ["run-driver"]}, {:env, env}])
+
     connection_name = Map.get(opts, :connection_name, Connection)
     {:ok, %__MODULE__{port: port, connection_name: connection_name}}
   end
@@ -105,4 +117,7 @@ defmodule PlaywrightEx.PortTransport do
     |> Serialization.deep_key_underscore()
     |> Map.update(:method, nil, &Serialization.underscore/1)
   end
+
+  defp maybe_charlist(value) when is_list(value), do: value
+  defp maybe_charlist(value) when is_binary(value), do: String.to_charlist(value)
 end

--- a/lib/playwright_ex/processes/port_transport.ex
+++ b/lib/playwright_ex/processes/port_transport.ex
@@ -31,7 +31,7 @@ defmodule PlaywrightEx.PortTransport do
   Start the PortTransport and link it to the connection process.
   """
   def start_link(opts) do
-    opts = Keyword.validate!(opts, [:executable, :name, :connection_name, :env])
+    opts = Keyword.validate!(opts, [:executable, :name, :connection_name, env: %{}])
     name = Keyword.get(opts, :name, @default_name)
     GenServer.start_link(__MODULE__, Map.new(opts), name: name)
   end

--- a/lib/playwright_ex/processes/port_transport.ex
+++ b/lib/playwright_ex/processes/port_transport.ex
@@ -43,7 +43,7 @@ defmodule PlaywrightEx.PortTransport do
 
   @impl GenServer
   def init(%{executable: executable, env: env} = opts) do
-    env = Enum.map(env, fn {k, v} -> {maybe_charlist(k), maybe_charlist(v)} end)
+    env = Enum.map(env, fn {k, v} -> {String.to_charlist(k), String.to_charlist(v)} end)
     port = Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, args: ["run-driver"], env: env])
     connection_name = Map.get(opts, :connection_name, Connection)
     {:ok, %__MODULE__{port: port, connection_name: connection_name}}
@@ -106,7 +106,4 @@ defmodule PlaywrightEx.PortTransport do
     |> Serialization.deep_key_underscore()
     |> Map.update(:method, nil, &Serialization.underscore/1)
   end
-
-  defp maybe_charlist(value) when is_list(value), do: value
-  defp maybe_charlist(value) when is_binary(value), do: String.to_charlist(value)
 end

--- a/lib/playwright_ex/processes/port_transport.ex
+++ b/lib/playwright_ex/processes/port_transport.ex
@@ -50,7 +50,7 @@ defmodule PlaywrightEx.PortTransport do
 
   def init(%{executable: executable, env: env} = opts) when map_size(env) > 0 do
     env = Enum.map(env, fn {k, v} -> {maybe_charlist(k), maybe_charlist(v)} end)
-    port = Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, {:args, ["run-driver"]}, {:env, env}])
+    port = Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, args: ["run-driver"], env: env])
     connection_name = Map.get(opts, :connection_name, Connection)
     {:ok, %__MODULE__{port: port, connection_name: connection_name}}
   end

--- a/lib/playwright_ex/processes/port_transport.ex
+++ b/lib/playwright_ex/processes/port_transport.ex
@@ -42,13 +42,7 @@ defmodule PlaywrightEx.PortTransport do
   end
 
   @impl GenServer
-  def init(%{executable: executable, env: env} = opts) when map_size(env) == 0 do
-    port = Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, args: ["run-driver"]])
-    connection_name = Map.get(opts, :connection_name, Connection)
-    {:ok, %__MODULE__{port: port, connection_name: connection_name}}
-  end
-
-  def init(%{executable: executable, env: env} = opts) when map_size(env) > 0 do
+  def init(%{executable: executable, env: env} = opts) do
     env = Enum.map(env, fn {k, v} -> {maybe_charlist(k), maybe_charlist(v)} end)
     port = Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, args: ["run-driver"], env: env])
     connection_name = Map.get(opts, :connection_name, Connection)

--- a/lib/playwright_ex/supervisor.ex
+++ b/lib/playwright_ex/supervisor.ex
@@ -11,6 +11,7 @@ defmodule PlaywrightEx.Supervisor do
     If provided, uses WebSocket transport. Otherwise uses local Port.
     If no browser param is provided, `chromium` is used by default.
   - `:executable` - Path to playwright CLI (only for Port transport)
+  - `:env` - A `%{String.t() => String.t()}` map of environment variables to set for the browser instance (only for Port transport).
   - `:timeout` - Connection timeout
   - `:js_logger` - Module for logging JS console messages
   - `:name` - Optional name for this supervisor instance. Defaults to `PlaywrightEx.Supervisor`.
@@ -43,7 +44,8 @@ defmodule PlaywrightEx.Supervisor do
         :fail_on_unknown_opts,
         executable: "playwright",
         js_logger: nil,
-        name: __MODULE__
+        name: __MODULE__,
+        env: %{}
       ])
 
     Supervisor.start_link(__MODULE__, Map.new(opts), name: opts[:name])
@@ -100,12 +102,12 @@ defmodule PlaywrightEx.Supervisor do
     {child_spec, {WebSocketTransport, transport_name}}
   end
 
-  defp transport_child_spec(%{executable: executable, name: name}, connection_name) do
+  defp transport_child_spec(%{executable: executable, name: name, env: env}, connection_name) do
     executable = validate_executable!(executable)
 
     transport_name = Module.concat(name, "PortTransport")
 
-    child_spec = {PortTransport, executable: executable, name: transport_name, connection_name: connection_name}
+    child_spec = {PortTransport, executable: executable, name: transport_name, connection_name: connection_name, env: env}
     {child_spec, {PortTransport, transport_name}}
   end
 


### PR DESCRIPTION
The port transport currently does not allow setting the environment, meaning that we can't set any environment variables for Playwright to use. For example, if we want to change the downloaded browser cache to scope it to a specific folder, we need to set the `PLAYWRIGHT_BROWSERS_PATH` to the directory where they are downloaded ([docs here](https://playwright.dev/docs/browsers)).

This allows passing an `:env` option to the supervisor on startup and ensures that we can pass an explicit environment to the Port transport.