### PR TITLE
fix: Use correct casing for ignoreHTTPSErrors

### DIFF
--- a/lib/playwright_ex/periphery/serialization.ex
+++ b/lib/playwright_ex/periphery/serialization.ex
@@ -3,6 +3,7 @@ defmodule PlaywrightEx.Serialization do
 
   def camelize(:inner_html), do: "innerHTML"
   def camelize(:base_url), do: "baseURL"
+  def camelize(:ignore_https_errors), do: "ignoreHTTPSErrors"
   def camelize(input), do: input |> to_string() |> camelize(:lower)
   def underscore(string), do: string |> Macro.underscore() |> String.to_atom()
 


### PR DESCRIPTION
Fixes #43 

Optional follow-up: Instead of an explicit whitelist of the entire option/key names, we should handle key fragments (any option that contains `https/url//html`).