### PR TITLE
feat (Frame): Accept all supported options to `goto`

### DIFF
--- a/lib/playwright_ex/channels/frame.ex
+++ b/lib/playwright_ex/channels/frame.ex
@@ -21,6 +21,22 @@ defmodule PlaywrightEx.Frame do
         required: true,
         doc:
           "The destination URL, including scheme (e.g., `https://`) or a relative path (`base_url` was passed to `PlaywrightEx.Browser.new_context/2`)."
+      ],
+      referer: [
+        type: :string,
+        doc:
+          "Referer header value. If provided, takes preference over the referer header set via the `extra_http_headers` option to `PlaywrightEx.Browser.new_context/2`."
+      ],
+      wait_until: [
+        type: {:in, ["load", "domcontentloaded", "networkidle", "commit"]},
+        default: "load",
+        doc: """
+        When to consider the operation succeeded. One of:
+        - `"load"` (default) — fires when the `load` event is fired.
+        - `"domcontentloaded"` — fires when the `DOMContentLoaded` event is fired.
+        - `"networkidle"` — **discouraged** — fires when there are no network connections for at least 500 ms. Rely on web assertions instead for testing readiness.
+        - `"commit"` — fires when the network response is received and the document has started loading.
+        """
       ]
     )
 

--- a/test/playwright_ex/frame_test.exs
+++ b/test/playwright_ex/frame_test.exs
@@ -7,6 +7,35 @@ defmodule PlaywrightEx.FrameTest do
 
   doctest PlaywrightEx
 
+  describe "goto/2" do
+    test "navigates with default options", %{frame: frame} do
+      assert {:ok, _} = Frame.goto(frame.guid, url: "about:blank", timeout: @timeout)
+    end
+
+    for wait_until <- ["load", "domcontentloaded", "networkidle", "commit"] do
+      @tag wait_until: wait_until
+      test "accepts `wait_until: #{inspect(wait_until)}`", %{frame: frame, wait_until: wait_until} do
+        assert {:ok, _} =
+                 Frame.goto(frame.guid, url: "about:blank", wait_until: wait_until, timeout: @timeout)
+      end
+    end
+
+    test "raises on invalid wait_until", %{frame: frame} do
+      assert_raise NimbleOptions.ValidationError, ~r/wait_until/, fn ->
+        Frame.goto(frame.guid, url: "about:blank", wait_until: "bogus", timeout: @timeout)
+      end
+    end
+
+    test "referer option sets the Referer header on the navigation request", %{frame: frame} do
+      referer = "https://example.com/"
+
+      {:ok, _} =
+        Frame.goto(frame.guid, url: "https://elixir-lang.org/", referer: referer, timeout: @timeout)
+
+      assert {:ok, ^referer} = Frame.evaluate(frame.guid, expression: "document.referrer", timeout: @timeout)
+    end
+  end
+
   describe "mouse move" do
     test "move, down, up", %{page: page, frame: frame} do
       # Navigate to a page with a clickable link


### PR DESCRIPTION
This expands the list of selected options for `PlaywrightEx.Frame.goto/2` to match those of the JavaScript API ([docs](https://playwright.dev/docs/api/class-page#page-goto)).

I found that in CI, I was often hitting 30 second timeouts waiting for the `load` event—even though in the trace, I could clearly see the page had (at least conceptually!) loaded. When switching to `waitUntil: 'commit'` (rather than the default `waitUntil: 'load'`), not only did the flakiness of that initial page load get fixed, but the tests also got _much_ faster: from an average of >5 seconds per test down to under 1.5 seconds/test.

(The `Referer` stuff isn't strictly necessary for my own work, but I figured while I was in here, I might as well make `goto` accept everything the JavaScript version does.)