### PR TITLE
feat: Add Page.expect_screenshot/2

### DIFF
--- a/lib/playwright_ex/channels/page.ex
+++ b/lib/playwright_ex/channels/page.ex
@@ -420,12 +420,13 @@ defmodule PlaywrightEx.Page do
       max_diff_pixel_ratio: [type: :float, doc: "Max ratio (0-1) of differing pixels."],
       threshold: [type: :float, doc: "Per-pixel color distance tolerance (0-1)."],
       full_page: [type: :boolean, doc: "Capture the full scrollable page."],
+      locator: [type: :map, doc: "Scope the assertion to a sub-element: `%{frame: %{guid: frame_guid}, selector: string}`."],
       clip: [type: :map, doc: "`%{x: float, y: float, width: float, height: float}`"],
       omit_background: [type: :boolean, doc: "Transparent background (PNG only)."],
       caret: [type: {:in, ["hide", "initial"]}],
       animations: [type: {:in, ["disabled", "allow"]}],
       scale: [type: {:in, ["css", "device"]}],
-      mask: [type: :any, doc: "List of `%{frame: guid_string, selector: string}`."],
+      mask: [type: :any, doc: "List of `%{frame: %{guid: frame_guid}, selector: string}`."],
       mask_color: [type: :string, doc: "Colour for masked areas."],
       style: [type: :string, doc: "CSS to apply before screenshotting."]
     )

--- a/lib/playwright_ex/channels/page.ex
+++ b/lib/playwright_ex/channels/page.ex
@@ -415,12 +415,15 @@ defmodule PlaywrightEx.Page do
       timeout: PlaywrightEx.Channel.timeout_opt(),
       is_not: [type: :boolean, default: false],
       expected: [type: :any, doc: "Baseline PNG binary. `nil` = capture-only mode."],
-      comparator: [type: :string],
+      comparator: [type: {:in, ["pixelmatch", "ssim-cie94"]}, default: "pixelmatch"],
       max_diff_pixels: [type: :integer, doc: "Max absolute pixel count allowed to differ."],
       max_diff_pixel_ratio: [type: :float, doc: "Max ratio (0-1) of differing pixels."],
       threshold: [type: :float, doc: "Per-pixel color distance tolerance (0-1)."],
       full_page: [type: :boolean, doc: "Capture the full scrollable page."],
-      locator: [type: :map, doc: "Scope the assertion to a sub-element: `%{frame: %{guid: frame_guid}, selector: string}`."],
+      locator: [
+        type: :map,
+        doc: "Scope the assertion to a sub-element: `%{frame: %{guid: frame_guid}, selector: string}`."
+      ],
       clip: [type: :map, doc: "`%{x: float, y: float, width: float, height: float}`"],
       omit_background: [type: :boolean, doc: "Transparent background (PNG only)."],
       caret: [type: {:in, ["hide", "initial"]}],
@@ -454,7 +457,7 @@ defmodule PlaywrightEx.Page do
     |> Connection.send(%{guid: page_id, method: :expectScreenshot, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
     |> case do
-      {:ok, result} when is_map_key(result, :error_message) -> {:error, result}
+      {:ok, %{error_message: _} = result} -> {:error, result}
       {:ok, result} -> {:ok, result[:actual]}
       {:error, _} = error -> error
     end

--- a/lib/playwright_ex/channels/page.ex
+++ b/lib/playwright_ex/channels/page.ex
@@ -409,6 +409,56 @@ defmodule PlaywrightEx.Page do
     |> ChannelResponse.unwrap(fn _ -> :ok end)
   end
 
+  schema =
+    NimbleOptions.new!(
+      connection: PlaywrightEx.Channel.connection_opt(),
+      timeout: PlaywrightEx.Channel.timeout_opt(),
+      is_not: [type: :boolean, default: false],
+      expected: [type: :any, doc: "Baseline PNG binary. `nil` = capture-only mode."],
+      comparator: [type: :string],
+      max_diff_pixels: [type: :integer, doc: "Max absolute pixel count allowed to differ."],
+      max_diff_pixel_ratio: [type: :float, doc: "Max ratio (0-1) of differing pixels."],
+      threshold: [type: :float, doc: "Per-pixel color distance tolerance (0-1)."],
+      full_page: [type: :boolean, doc: "Capture the full scrollable page."],
+      clip: [type: :map, doc: "`%{x: float, y: float, width: float, height: float}`"],
+      omit_background: [type: :boolean, doc: "Transparent background (PNG only)."],
+      caret: [type: {:in, ["hide", "initial"]}],
+      animations: [type: {:in, ["disabled", "allow"]}],
+      scale: [type: {:in, ["css", "device"]}],
+      mask: [type: :any, doc: "List of `%{frame: guid_string, selector: string}`."],
+      mask_color: [type: :string, doc: "Colour for masked areas."],
+      style: [type: :string, doc: "CSS to apply before screenshotting."]
+    )
+
+  @doc """
+  Asserts that a screenshot of the page matches the provided baseline.
+
+  Pass `expected: nil` (or omit it) for capture-only mode — the server takes a screenshot
+  and returns the PNG bytes without performing any comparison.
+
+  Reference: https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1
+
+  ## Options
+  #{NimbleOptions.docs(schema)}
+  """
+  @schema schema
+  @type expect_screenshot_opt :: unquote(NimbleOptions.option_typespec(schema))
+  @spec expect_screenshot(PlaywrightEx.guid(), [expect_screenshot_opt() | PlaywrightEx.unknown_opt()]) ::
+          {:ok, binary() | nil} | {:error, any()}
+  def expect_screenshot(page_id, opts \\ []) do
+    {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
+    {timeout, opts} = Keyword.pop!(opts, :timeout)
+
+    connection
+    |> Connection.send(%{guid: page_id, method: :expectScreenshot, params: Map.new(opts)}, timeout)
+    |> ChannelResponse.unwrap(& &1)
+    |> case do
+      {:ok, result} when is_map_key(result, :error_message) -> {:error, result}
+      {:ok, result} -> {:ok, result[:actual]}
+      {:error, _} = error -> error
+    end
+  end
+
   defp main_frame_id!(connection, page_id) do
     page_initializer = Connection.initializer!(connection, page_id)
     page_initializer.main_frame.guid

--- a/test/playwright_ex/page_test.exs
+++ b/test/playwright_ex/page_test.exs
@@ -37,6 +37,65 @@ defmodule PlaywrightEx.PageTest do
     end
   end
 
+  # 1×1 red pixel PNG — used as a baseline guaranteed to differ from any full-page screenshot
+  @one_by_one_png "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+  describe "expect_screenshot/2" do
+    test "returns base64-encoded PNG in capture-only mode", %{page: page, frame: frame} do
+      {:ok, _} = Frame.goto(frame.guid, url: "about:blank", timeout: @timeout)
+
+      # "iVBORw0K" is the base64 encoding of the 6-byte PNG magic header
+      assert {:ok, <<"iVBORw0K", _::binary>>} =
+               Page.expect_screenshot(page.guid, timeout: @timeout)
+    end
+
+    test "succeeds when actual matches baseline", %{page: page, frame: frame} do
+      {:ok, _} = Frame.goto(frame.guid, url: "about:blank", timeout: @timeout)
+      {:ok, baseline} = Page.expect_screenshot(page.guid, timeout: @timeout)
+
+      assert {:ok, _} = Page.expect_screenshot(page.guid, expected: baseline, timeout: @timeout)
+    end
+
+    test "returns error when actual does not match baseline", %{page: page, frame: frame} do
+      {:ok, _} = Frame.goto(frame.guid, url: "about:blank", timeout: @timeout)
+
+      assert {:error,
+              %{
+                timed_out: false,
+                error_message:
+                  "Expected an image 1px by 1px, received 1280px by 720px. 1 pixels (ratio 0.01 of all image pixels) are different.",
+                log: _,
+                diff: _,
+                actual: _
+              }} =
+               Page.expect_screenshot(page.guid, expected: @one_by_one_png, timeout: @timeout)
+    end
+
+    test "clips screenshot to element bounding box", %{page: page, frame: frame} do
+      :ok = set_html(frame.guid, "<div id='target' style='width:100px;height:50px;background:blue'></div>")
+      {:ok, box} = eval(frame.guid, "() => document.getElementById('target').getBoundingClientRect().toJSON()")
+
+      clip = %{x: box["x"], y: box["y"], width: box["width"], height: box["height"]}
+
+      assert {:ok, <<"iVBORw0K", _::binary>>} =
+               Page.expect_screenshot(page.guid, clip: clip, timeout: @timeout)
+    end
+
+    test "accepts full_page option", %{page: page, frame: frame} do
+      {:ok, _} = Frame.goto(frame.guid, url: "about:blank", timeout: @timeout)
+
+      assert {:ok, <<"iVBORw0K", _::binary>>} =
+               Page.expect_screenshot(page.guid, full_page: true, timeout: @timeout)
+    end
+
+    test "is_not: true succeeds when screenshots differ", %{page: page, frame: frame} do
+      {:ok, _} = Frame.goto(frame.guid, url: "about:blank", timeout: @timeout)
+
+      assert {:ok, _} =
+               Page.expect_screenshot(page.guid, expected: @one_by_one_png, is_not: true, timeout: @timeout)
+    end
+  end
+
   describe "expect_url/2" do
     test "matches current URL with string expectation", %{page: page, frame: frame} do
       {:ok, _} = Frame.goto(frame.guid, url: "about:blank#current", timeout: @timeout)

--- a/test/playwright_ex/page_test.exs
+++ b/test/playwright_ex/page_test.exs
@@ -37,7 +37,7 @@ defmodule PlaywrightEx.PageTest do
     end
   end
 
-  # 1×1 red pixel PNG — used as a baseline guaranteed to differ from any full-page screenshot
+  # 1×1 red pixel PNG
   @one_by_one_png "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGL5z8AAAAAA//+FDQv1AAAABklEQVQDAAMRAQSnRfifAAAAAElFTkSuQmCC"
 
   describe "expect_screenshot/2" do
@@ -72,13 +72,13 @@ defmodule PlaywrightEx.PageTest do
     end
 
     test "clips screenshot to element bounding box", %{page: page, frame: frame} do
-      :ok = set_html(frame.guid, "<div id='target' style='width:100px;height:50px;background:blue'></div>")
+      :ok = set_html(frame.guid, "<div id='target' style='width:1px;height:1px;background:#FF0000'></div>")
       {:ok, box} = eval(frame.guid, "() => document.getElementById('target').getBoundingClientRect().toJSON()")
 
       clip = %{x: box["x"], y: box["y"], width: box["width"], height: box["height"]}
 
-      assert {:ok, <<"iVBORw0K", _::binary>>} =
-               Page.expect_screenshot(page.guid, clip: clip, timeout: @timeout)
+      assert {:ok, nil} =
+               Page.expect_screenshot(page.guid, clip: clip, expected: @one_by_one_png, timeout: @timeout)
     end
 
     test "scopes screenshot to locator", %{page: page, frame: frame} do

--- a/test/playwright_ex/page_test.exs
+++ b/test/playwright_ex/page_test.exs
@@ -38,7 +38,7 @@ defmodule PlaywrightEx.PageTest do
   end
 
   # 1×1 red pixel PNG — used as a baseline guaranteed to differ from any full-page screenshot
-  @one_by_one_png "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+  @one_by_one_png "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGL5z8AAAAAA//+FDQv1AAAABklEQVQDAAMRAQSnRfifAAAAAElFTkSuQmCC"
 
   describe "expect_screenshot/2" do
     test "returns base64-encoded PNG in capture-only mode", %{page: page, frame: frame} do
@@ -79,6 +79,17 @@ defmodule PlaywrightEx.PageTest do
 
       assert {:ok, <<"iVBORw0K", _::binary>>} =
                Page.expect_screenshot(page.guid, clip: clip, timeout: @timeout)
+    end
+
+    test "scopes screenshot to locator", %{page: page, frame: frame} do
+      :ok = set_html(frame.guid, "<div id='target' style='width:1px;height:1px;background:#FF0000'></div>")
+
+      assert {:ok, nil} =
+               Page.expect_screenshot(page.guid,
+                 locator: %{frame: %{guid: frame.guid}, selector: "#target"},
+                 expected: @one_by_one_png,
+                 timeout: @timeout
+               )
     end
 
     test "accepts full_page option", %{page: page, frame: frame} do


### PR DESCRIPTION
`@playwright/test` ships `toHaveScreenshot` for visual regression testing, but the underlying `expectScreenshot` protocol command was not exposed in this library. This PR adds `Page.expect_screenshot/2`, including a `locator` opt to scope the screenshot to a specific element, to support building a `toHaveScreenshot`-equivalent helper in Elixir.