### PR TITLE
Support Playwright 1.61 Frame.expect wire contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 <!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
 ## [Unreleased]
+### Fixed
+- Support the Playwright 1.61 `Frame.expect` wire contract. 1.61 stopped
+  returning `%{matches: boolean}` and now signals the assertion outcome by
+  success-vs-error: a non-match returns a protocol error carrying
+  `error_details`. `Frame.expect/2` now yields a plain `{:ok, boolean}` under
+  both 1.60 and 1.61, so `phoenix_test_playwright`'s `assert_has`/`refute_has`
+  keep working. `PlaywrightEx.Serialization.deserialize_arg/1` also raises a
+  descriptive error on unknown serialized shapes instead of a bare
+  `CaseClauseError`. [@oliver-kriska]
 
 ## [0.6.0] 2026-05-05
 ### Added

--- a/lib/playwright_ex/channels/frame.ex
+++ b/lib/playwright_ex/channels/frame.ex
@@ -273,10 +273,11 @@ defmodule PlaywrightEx.Frame do
   def expect(frame_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    is_not = Keyword.get(opts, :is_not, false)
 
     connection
     |> Connection.send(%{guid: frame_id, method: :expect, params: Map.new(opts)}, timeout)
-    |> ChannelResponse.unwrap(& &1.matches)
+    |> ChannelResponse.unwrap_expect(is_not)
   end
 
   schema =

--- a/lib/playwright_ex/periphery/channel_response.ex
+++ b/lib/playwright_ex/periphery/channel_response.ex
@@ -8,6 +8,21 @@ defmodule PlaywrightEx.ChannelResponse do
   def unwrap(%{result: result}, fun) when is_function(fun, 1), do: {:ok, fun.(result)}
   def unwrap(other, fun) when is_function(fun, 1), do: {:ok, other}
 
+  @doc """
+  Unwraps a `Frame.expect` reply into `{:ok, matches?}`, applying `is_not`.
+
+  Playwright 1.60 replied `%{result: %{matches: boolean}}`. 1.61 dropped that
+  field and signals the outcome by success-vs-error: a non-match returns an
+  error carrying `error_details`. Mirrors playwright-core's `Frame._expect`, so
+  `matches?` (raw positive-condition result, `is_not` applied) stays identical
+  across drivers; a genuine 1.60 error still propagates as `{:error, _}`.
+  """
+  @spec unwrap_expect(map(), boolean()) :: {:ok, boolean()} | {:error, any()}
+  def unwrap_expect(%{result: %{matches: matches}}, _is_not) when is_boolean(matches), do: {:ok, matches}
+  def unwrap_expect(%{error_details: _details}, is_not) when is_boolean(is_not), do: {:ok, is_not}
+  def unwrap_expect(%{error: error}, _is_not), do: {:error, error}
+  def unwrap_expect(reply, is_not) when is_map(reply) and is_boolean(is_not), do: {:ok, not is_not}
+
   @spec unwrap_create(any(), atom(), GenServer.name()) :: {:ok, any()} | {:error, any()}
   def unwrap_create(value, resource_name, connection) when is_atom(resource_name) do
     unwrap(value, fn result ->

--- a/lib/playwright_ex/periphery/serialization.ex
+++ b/lib/playwright_ex/periphery/serialization.ex
@@ -71,6 +71,11 @@ defmodule PlaywrightEx.Serialization do
 
       %{ref: _} ->
         :ref_not_resolved
+
+      other ->
+        raise ArgumentError,
+              "PlaywrightEx.Serialization.deserialize_arg/1: unsupported serialized value shape " <>
+                "(Playwright protocol drift?): #{inspect(other, limit: 20)}"
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PlaywrightEx.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.7.0"
   @source_url "https://github.com/ftes/playwright_ex"
   @description """
   Elixir client for the Playwright node.js driver.

--- a/test/playwright_ex/frame_expect_test.exs
+++ b/test/playwright_ex/frame_expect_test.exs
@@ -1,0 +1,54 @@
+defmodule PlaywrightEx.FrameExpectTest do
+  @moduledoc """
+  End-to-end coverage for `Frame.expect/2`, which must return the same
+  `{:ok, boolean}` under both the 1.60 and 1.61 driver wire contracts.
+  """
+  use PlaywrightExCase, async: true
+
+  alias PlaywrightEx.Frame
+
+  setup %{frame: frame} do
+    set_html(frame.guid, ~s(<div id="present">hello</div>))
+    :ok
+  end
+
+  describe "expect/2 visibility (driver-version agnostic)" do
+    test "present element, is_not: false -> matches true", %{frame: frame} do
+      assert {:ok, true} =
+               Frame.expect(frame.guid,
+                 selector: "#present",
+                 expression: "to.be.visible",
+                 is_not: false,
+                 timeout: @timeout
+               )
+    end
+
+    test "absent element, is_not: false -> matches false", %{frame: frame} do
+      assert {:ok, false} =
+               Frame.expect(frame.guid,
+                 selector: "#missing",
+                 expression: "to.be.visible",
+                 is_not: false,
+                 timeout: @timeout
+               )
+    end
+
+    test "absent element, is_not: true (expect-not-visible satisfied) -> matches false", %{frame: frame} do
+      assert {:ok, false} =
+               Frame.expect(frame.guid,
+                 selector: "#missing",
+                 expression: "to.be.visible",
+                 is_not: true,
+                 timeout: @timeout
+               )
+    end
+
+    test "assert_has finds a present element", %{frame: frame} do
+      assert_has(frame.guid, "#present")
+    end
+
+    test "refute_has on an absent element", %{frame: frame} do
+      refute_has(frame.guid, "#missing")
+    end
+  end
+end

--- a/test/playwright_ex/periphery/channel_response_test.exs
+++ b/test/playwright_ex/periphery/channel_response_test.exs
@@ -1,0 +1,40 @@
+defmodule PlaywrightEx.ChannelResponseTest do
+  use ExUnit.Case, async: true
+
+  alias PlaywrightEx.ChannelResponse
+
+  describe "unwrap_expect/2" do
+    test "1.60 reply: trusts result.matches regardless of is_not" do
+      assert {:ok, true} = ChannelResponse.unwrap_expect(%{id: 1, result: %{matches: true}}, false)
+      assert {:ok, false} = ChannelResponse.unwrap_expect(%{id: 1, result: %{matches: false}}, false)
+      assert {:ok, true} = ChannelResponse.unwrap_expect(%{id: 1, result: %{matches: true}}, true)
+    end
+
+    test "1.61 satisfied reply (no result/error): matches == not is_not" do
+      assert {:ok, true} = ChannelResponse.unwrap_expect(%{id: 6, method: nil}, false)
+      assert {:ok, false} = ChannelResponse.unwrap_expect(%{id: 6, method: nil}, true)
+    end
+
+    test "1.61 unsatisfied reply (error + error_details): matches == is_not" do
+      reply = %{
+        id: 27,
+        method: nil,
+        error: %{error: %{message: "Expect failed", name: "ExpectError", stack: "..."}},
+        log: ["  - Expect \"to.be.visible\" with timeout 2000ms"],
+        error_details: %{
+          timed_out: true,
+          received: %{value: %{v: "undefined"}, aria_snapshot: "- text: hello"},
+          custom_error_message: "element(s) not found"
+        }
+      }
+
+      assert {:ok, false} = ChannelResponse.unwrap_expect(reply, false)
+      assert {:ok, true} = ChannelResponse.unwrap_expect(reply, true)
+    end
+
+    test "genuine protocol error without error_details still propagates" do
+      reply = %{id: 9, error: %{error: %{message: "boom", name: "Error", stack: "..."}}}
+      assert {:error, %{error: %{name: "Error"}}} = ChannelResponse.unwrap_expect(reply, false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Playwright 1.61 changed the internal `Frame.expect` wire contract. Instead of always returning `%{matches: boolean}`, the command now signals the assertion outcome by **success-vs-error**: a satisfied expectation resolves with an empty reply, and an unsatisfied one returns a protocol error carrying a top-level `errorDetails` (`received` / `timedOut` / `customErrorMessage`). The `matches` field no longer exists on the wire.

Confirmed against `microsoft/playwright` source between `v1.60.0` and `v1.61.0`:
- `packages/protocol/spec/frame.yml` — the `expect` command's `returns:` block (with `matches`) was replaced by an `errorDetails:` block.
- `packages/playwright-core/src/client/frame.ts` `_expect` now `try/catch`es the channel call: success → `{matches: !isNot}`, caught `PlaywrightError` → `{matches: !!isNot}` from `errorDetails`.

Because of this, `ChannelResponse.unwrap(& &1.matches)` fell through to the silent `unwrap(other, _) -> {:ok, other}` fallback and returned a non-boolean, breaking downstream visibility/text assertions (e.g. `phoenix_test_playwright`'s `assert_has` / `refute_has`).

## Changes

- Add `ChannelResponse.unwrap_expect/2`, mirroring playwright-core's `Frame._expect`. It applies `is_not` and returns a plain `{:ok, boolean}`:
  - `1.60`: trusts `result.matches`.
  - `1.61` satisfied (no error): `matches = not is_not`.
  - `1.61` unsatisfied (error + `error_details`): `matches = is_not`.
  - genuine protocol error without `error_details` still propagates as `{:error, _}`.
- `Frame.expect/2` reads `is_not` and calls `unwrap_expect/2`.
- `Serialization.deserialize_arg/1` gets a descriptive catch-all instead of a bare `CaseClauseError`.
- Tests: browser-driven `frame_expect_test.exs` plus browser-free `channel_response_test.exs` locking the exact wire shapes from each driver.

## Verification

Full suite (107 tests) green against **both** `playwright@1.60.0` and `playwright@1.61.0`. `expect` was the only command whose wire contract broke under 1.61; navigation/click/fill/wait paths are unaffected.

Note: not introduced here, but `port_transport.ex:88` already emits a pin-operator warning that fails `mix compile --warnings-as-errors` on recent Elixir — worth a separate cleanup.