### PR TITLE
Support typed in-memory and file-chooser uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 <!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
+## [Unreleased]
+### Added
+- `PlaywrightEx.FilePayload` for typed in-memory file uploads.
+  `Frame.set_input_files/2` and the new `ElementHandle.set_input_files/2` accept
+  paths or payloads, with the latter supporting handles from file chooser
+  events. Empty selections clear inputs for both local and remote connections.
+  #80
+
 ## [0.8.0] 2026-08-27
 ### Changed
 - Require Playwright 1.62 or newer. Command timeouts are now sent as protocol

--- a/lib/playwright_ex/channels/element_handle.ex
+++ b/lib/playwright_ex/channels/element_handle.ex
@@ -1,0 +1,48 @@
+defmodule PlaywrightEx.ElementHandle do
+  @moduledoc """
+  Interact with a Playwright `ElementHandle`.
+
+  There is no official channel documentation, since this is considered
+  Playwright internal.
+
+  Reference: https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/client/elementHandle.ts
+  """
+
+  alias PlaywrightEx.ChannelResponse
+  alias PlaywrightEx.Connection
+  alias PlaywrightEx.FileInput
+
+  schema =
+    NimbleOptions.new!(
+      [
+        connection: PlaywrightEx.Channel.connection_opt(),
+        timeout: PlaywrightEx.Channel.timeout_opt()
+      ] ++ FileInput.selection_schema()
+    )
+
+  @doc """
+  Sets the files on the input element represented by this handle.
+
+  Pass either `:local_paths` or `:payloads`. An empty list clears the selected
+  files. This operation can be used with the element handle carried by a
+  subscribed page's `:file_chooser` event.
+
+  Reference: https://playwright.dev/docs/api/class-filechooser#file-chooser-set-files
+
+  ## Options
+  #{NimbleOptions.docs(schema)}
+  """
+  @schema schema
+  @type set_input_files_opt :: unquote(NimbleOptions.option_typespec(schema))
+  @spec set_input_files(PlaywrightEx.guid(), [set_input_files_opt() | PlaywrightEx.unknown_opt()]) ::
+          {:ok, any()} | {:error, any()}
+  def set_input_files(element_id, opts \\ []) do
+    {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
+    {timeout, opts} = Keyword.pop!(opts, :timeout)
+    params = opts |> FileInput.prepare(connection) |> Map.new()
+
+    connection
+    |> Connection.send(%{guid: element_id, method: :set_input_files, params: params}, timeout)
+    |> ChannelResponse.unwrap(& &1)
+  end
+end

--- a/lib/playwright_ex/channels/frame.ex
+++ b/lib/playwright_ex/channels/frame.ex
@@ -573,33 +573,29 @@ defmodule PlaywrightEx.Frame do
 
   schema =
     NimbleOptions.new!(
-      connection: PlaywrightEx.Channel.connection_opt(),
-      timeout: PlaywrightEx.Channel.timeout_opt(),
-      selector: [
-        type: :string,
-        required: true,
-        doc: "A selector to search for an element."
-      ],
-      local_paths: [
-        type: :any,
-        required: true,
-        doc:
-          "File path(s) to set. Can be a string or a list of strings. Relative paths are resolved relative to the current working directory."
-      ],
-      strict: [
-        type: :boolean,
-        default: true,
-        doc: "When true, the call requires selector to resolve to a single element."
-      ]
+      [
+        connection: PlaywrightEx.Channel.connection_opt(),
+        timeout: PlaywrightEx.Channel.timeout_opt(),
+        selector: [
+          type: :string,
+          required: true,
+          doc: "A selector to search for an element."
+        ],
+        strict: [
+          type: :boolean,
+          default: true,
+          doc: "When true, the call requires selector to resolve to a single element."
+        ]
+      ] ++ PlaywrightEx.FileInput.selection_schema()
     )
 
   @doc """
-  Sets the value of the file input to these file paths or files.
+  Sets the value of the file input to local file paths or in-memory payloads.
 
   This method expects selector to point to an input element. However, if the element is inside
-  the `<label>` element that has an associated control, targets the control instead. If some of
-  the file paths are relative paths, then they are resolved relative to the current working directory.
-  For empty array, clears the selected files.
+  the `<label>` element that has an associated control, targets the control instead. Pass either
+  `:local_paths` or `:payloads`. If some of the file paths are relative paths, then they are resolved
+  relative to the current working directory. An empty list clears the selected files.
 
   Note: This method is discouraged. Use locator-based `locator.setInputFiles()` instead.
 
@@ -616,29 +612,11 @@ defmodule PlaywrightEx.Frame do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
 
-    params = opts |> Map.new() |> maybe_convert_to_payloads(connection)
+    params = opts |> PlaywrightEx.FileInput.prepare(connection) |> Map.new()
 
     connection
     |> Connection.send(%{guid: frame_id, method: :set_input_files, params: params}, timeout)
     |> ChannelResponse.unwrap(& &1)
-  end
-
-  defp maybe_convert_to_payloads(%{local_paths: local_paths} = params, connection) do
-    if Connection.remote?(connection) do
-      paths = local_paths |> List.wrap() |> Enum.map(&Path.expand/1)
-
-      payloads =
-        Enum.map(paths, fn path ->
-          %{
-            name: Path.basename(path),
-            buffer: path |> File.read!() |> Base.encode64()
-          }
-        end)
-
-      params |> Map.delete(:local_paths) |> Map.put(:payloads, payloads)
-    else
-      params
-    end
   end
 
   schema =

--- a/lib/playwright_ex/file_input.ex
+++ b/lib/playwright_ex/file_input.ex
@@ -1,0 +1,76 @@
+defmodule PlaywrightEx.FileInput do
+  @moduledoc false
+
+  alias PlaywrightEx.Connection
+  alias PlaywrightEx.FilePayload
+
+  def selection_schema do
+    [
+      local_paths: [
+        type: {:or, [:string, {:list, :string}]},
+        doc:
+          "A file path or list of file paths. Relative paths are resolved relative to the current working directory. An empty list clears the selected files."
+      ],
+      payloads: [
+        type: {:or, [{:struct, FilePayload}, {:list, {:struct, FilePayload}}]},
+        type_spec: quote(do: FilePayload.t() | [FilePayload.t()]),
+        type_doc: "`PlaywrightEx.FilePayload.t() | [PlaywrightEx.FilePayload.t()]`",
+        doc: "An in-memory file payload or list of payloads. An empty list clears the selected files."
+      ]
+    ]
+  end
+
+  def prepare(opts, connection) do
+    case {Keyword.fetch(opts, :local_paths), Keyword.fetch(opts, :payloads)} do
+      {{:ok, _paths}, {:ok, _payloads}} ->
+        raise ArgumentError, "expected either :local_paths or :payloads, got both"
+
+      {:error, :error} ->
+        raise ArgumentError, "expected either :local_paths or :payloads"
+
+      {{:ok, paths}, :error} ->
+        prepare_local_paths(opts, List.wrap(paths), connection)
+
+      {:error, {:ok, payloads}} ->
+        prepare_payloads(opts, List.wrap(payloads))
+    end
+  end
+
+  defp prepare_local_paths(opts, [], _connection) do
+    opts |> Keyword.delete(:local_paths) |> Keyword.put(:payloads, [])
+  end
+
+  defp prepare_local_paths(opts, paths, connection) do
+    if Connection.remote?(connection) do
+      payloads =
+        Enum.map(paths, fn path ->
+          %FilePayload{name: Path.basename(path), buffer: File.read!(Path.expand(path))}
+        end)
+
+      opts |> Keyword.delete(:local_paths) |> put_serialized_payloads(payloads)
+    else
+      Keyword.put(opts, :local_paths, paths)
+    end
+  end
+
+  defp prepare_payloads(opts, payloads) do
+    opts |> Keyword.delete(:payloads) |> put_serialized_payloads(payloads)
+  end
+
+  defp put_serialized_payloads(opts, payloads) do
+    Keyword.put(opts, :payloads, Enum.map(payloads, &serialize_payload/1))
+  end
+
+  defp serialize_payload(%FilePayload{name: name, buffer: buffer, mime_type: mime_type} = payload)
+       when is_binary(name) and is_binary(buffer) and (is_binary(mime_type) or is_nil(mime_type)) do
+    %{name: payload.name, mime_type: payload.mime_type, buffer: Base.encode64(payload.buffer)}
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp serialize_payload(%FilePayload{} = payload) do
+    raise ArgumentError,
+          "expected a PlaywrightEx.FilePayload with binary :name and :buffer and an optional binary :mime_type, " <>
+            "got: #{inspect(payload)}"
+  end
+end

--- a/lib/playwright_ex/file_payload.ex
+++ b/lib/playwright_ex/file_payload.ex
@@ -1,0 +1,19 @@
+defmodule PlaywrightEx.FilePayload do
+  @moduledoc """
+  An in-memory file passed to a Playwright file input.
+
+  `buffer` contains the raw file bytes. It is base64-encoded only when the
+  payload is serialized for the Playwright protocol.
+
+  Reference: https://playwright.dev/docs/api/class-locator#locator-set-input-files
+  """
+
+  @enforce_keys [:name, :buffer]
+  defstruct [:name, :buffer, :mime_type]
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          buffer: binary(),
+          mime_type: String.t() | nil
+        }
+end

--- a/test/playwright_ex/element_handle_test.exs
+++ b/test/playwright_ex/element_handle_test.exs
@@ -1,0 +1,57 @@
+defmodule PlaywrightEx.ElementHandleTest do
+  use PlaywrightExCase, async: true
+
+  alias PlaywrightEx.ElementHandle
+  alias PlaywrightEx.FilePayload
+  alias PlaywrightEx.Frame
+  alias PlaywrightEx.Page
+
+  test "sets files on the element from a page file chooser event", %{page: page, frame: frame} do
+    :ok =
+      set_html(
+        frame.guid,
+        """
+        <input id="file-input" type="file" hidden>
+        <button id="choose" onclick="document.getElementById('file-input').click()">Choose file</button>
+        """
+      )
+
+    :ok = PlaywrightEx.subscribe(page.guid)
+
+    on_exit(fn ->
+      PlaywrightEx.unsubscribe(page.guid)
+    end)
+
+    assert {:ok, _} =
+             Page.update_subscription(page.guid,
+               event: :fileChooser,
+               enabled: true,
+               timeout: @timeout
+             )
+
+    assert {:ok, _} = Frame.click(frame.guid, selector: "#choose", timeout: @timeout)
+
+    assert_receive {:playwright_msg,
+                    %{
+                      guid: page_id,
+                      method: :file_chooser,
+                      params: %{element: %{guid: element_id}, is_multiple: false}
+                    }}
+
+    assert page_id == page.guid
+
+    assert {:ok, _} =
+             ElementHandle.set_input_files(element_id,
+               payloads: %FilePayload{name: "chosen.txt", mime_type: "text/plain", buffer: "chosen"},
+               timeout: @timeout
+             )
+
+    assert {:ok, %{"name" => "chosen.txt", "contents" => "chosen"}} =
+             eval(frame.guid, """
+             async () => {
+               const file = document.getElementById('file-input').files[0];
+               return {name: file.name, contents: await file.text()};
+             }
+             """)
+  end
+end

--- a/test/playwright_ex/frame_test.exs
+++ b/test/playwright_ex/frame_test.exs
@@ -1,6 +1,7 @@
 defmodule PlaywrightEx.FrameTest do
   use PlaywrightExCase, async: true
 
+  alias PlaywrightEx.FilePayload
   alias PlaywrightEx.Frame
   alias PlaywrightEx.Page
   alias PlaywrightEx.Selector
@@ -455,6 +456,84 @@ defmodule PlaywrightEx.FrameTest do
         assert file_content == "hello from elixir"
       after
         File.rm(tmp_path)
+      end
+    end
+
+    test "can upload an in-memory payload without changing its bytes", %{frame: frame} do
+      :ok = set_html(frame.guid, "<input id='file-input' type='file'>")
+      bytes = <<0, 1, 127, 128, 255>>
+
+      assert {:ok, _} =
+               Frame.set_input_files(frame.guid,
+                 selector: "#file-input",
+                 payloads: %FilePayload{
+                   name: "generated.bin",
+                   mime_type: "application/octet-stream",
+                   buffer: bytes
+                 },
+                 timeout: @timeout
+               )
+
+      assert {:ok,
+              %{
+                "name" => "generated.bin",
+                "type" => "application/octet-stream",
+                "bytes" => [0, 1, 127, 128, 255]
+              }} =
+               eval(frame.guid, """
+               async () => {
+                 const file = document.getElementById('file-input').files[0];
+                 return {
+                   name: file.name,
+                   type: file.type,
+                   bytes: Array.from(new Uint8Array(await file.arrayBuffer()))
+                 };
+               }
+               """)
+    end
+
+    test "an empty local path list clears selected files", %{frame: frame} do
+      :ok = set_html(frame.guid, "<input id='file-input' type='file'>")
+
+      assert {:ok, _} =
+               Frame.set_input_files(frame.guid,
+                 selector: "#file-input",
+                 payloads: %FilePayload{name: "generated.txt", buffer: "contents"},
+                 timeout: @timeout
+               )
+
+      assert {:ok, _} =
+               Frame.set_input_files(frame.guid,
+                 selector: "#file-input",
+                 local_paths: [],
+                 timeout: @timeout
+               )
+
+      assert {:ok, 0} = eval(frame.guid, "() => document.getElementById('file-input').files.length")
+    end
+
+    test "requires exactly one file source", %{frame: frame} do
+      assert_raise ArgumentError, ~r/expected either :local_paths or :payloads$/, fn ->
+        Frame.set_input_files(frame.guid, selector: "#file-input", timeout: @timeout)
+      end
+
+      assert_raise ArgumentError, ~r/got both/, fn ->
+        Frame.set_input_files(frame.guid,
+          selector: "#file-input",
+          local_paths: [],
+          payloads: [],
+          timeout: @timeout
+        )
+      end
+    end
+
+    test "validates in-memory payload fields", %{frame: frame} do
+      assert_raise ArgumentError, ~r/with binary :name and :buffer/, fn ->
+        Frame.set_input_files(frame.guid,
+          selector: "#file-input",
+          payloads: %FilePayload{name: "invalid.txt", buffer: :not_binary},
+          timeout: @timeout
+        )
       end
     end
   end


### PR DESCRIPTION
- add `PlaywrightEx.FilePayload` for validated, typed in-memory uploads
- support payloads through `Frame.set_input_files/2` without temporary files
- add `ElementHandle.set_input_files/2` for handles captured from `fileChooser` events
- normalize singular paths/payloads and encode empty selections as `payloads: []`, which correctly clears local and remote inputs
- share the same serialization across Port and WebSocket transports
