### PR TITLE
Support Playwright 1.63 protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   paths or payloads, with the latter supporting handles from file chooser
   events. Empty selections clear inputs for both local and remote connections.
   #80
+- Playwright 1.63 APIs for structured ARIA snapshots, OPFS storage-state
+  snapshots, browser-context `dialog_closed` events, visible-only selectors,
+  and selectors that search across descendant frames.
+
+### Changed
+- Require Playwright 1.63 or newer. The local port transport now raises for an
+  older driver instead of warning. HTTP credentials are serialized using the
+  new array wire format while the public API continues to accept one credential
+  map or a list.
+- Map the public tracing snapshot and screenshot options to Playwright 1.63's
+  `snapshotDom`, `snapshotAria`, `snapshotScreen`, and `screencast` wire fields.
 
 ## [0.8.0] 2026-08-27
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Freddy.
         # mix.exs
         {:playwright_ex, "~> 0.6"}
 
-2. Ensure `playwright` is installed (executable in `$PATH` or installed via `npm`)
+2. Ensure Playwright 1.63 or newer is installed (executable in `$PATH` or installed via `npm`)
 
 3. Start connection (or add to supervision tree)
         # if installed via npm or similar add `executable: "assets/node_modules/playwright/cli.js"`
@@ -37,7 +37,7 @@ Freddy.
         {:ok, _} = Frame.goto(frame.guid, "https://elixir-lang.org/", timeout: 1000)
         {:ok, _} = Frame.click(frame.guid, Selector.link("Install"), timeout: 1000)
 
-## Remove server via Websocket
+## Remote server via WebSocket
 By default, PlaywrightEx launches a local playwright driver.
 This is typically installed via `npm` or `bun`.
 
@@ -48,8 +48,8 @@ Alternatively, PlaywrightEx can connect to a remote playwright server:
 
   ```
   docker run -p 3000:3000 --rm --init -it \\
-    mcr.microsoft.com/playwright:v1.58.0-noble \\
-    npx -y playwright@1.58.0 run-server --port 3000 --host 0.0.0.0
+    mcr.microsoft.com/playwright:v1.63.0-noble \\
+    npx -y playwright@1.63.0 run-server --port 3000 --host 0.0.0.0
   ```
 
       {:ok, _} = PlaywrightEx.Supervisor.start_link(

--- a/lib/playwright_ex.ex
+++ b/lib/playwright_ex.ex
@@ -102,5 +102,5 @@ defmodule PlaywrightEx do
   end
 
   @doc false
-  def recommended_min_version, do: "1.62.0"
+  def minimum_supported_version, do: "1.63.0"
 end

--- a/lib/playwright_ex/channels/browser.ex
+++ b/lib/playwright_ex/channels/browser.ex
@@ -40,8 +40,27 @@ defmodule PlaywrightEx.Browser do
         doc: "An object containing additional HTTP headers to be sent with every request."
       ],
       http_credentials: [
-        type: :any,
-        doc: "Credentials for HTTP authentication. Map with `:username` and `:password`."
+        type: {:or, [:map, {:list, :map}]},
+        type_spec:
+          quote(
+            do:
+              %{
+                required(:username) => String.t(),
+                required(:password) => String.t(),
+                optional(:origin) => String.t(),
+                optional(:send) => :always | :unauthorized
+              }
+              | [
+                  %{
+                    required(:username) => String.t(),
+                    required(:password) => String.t(),
+                    optional(:origin) => String.t(),
+                    optional(:send) => :always | :unauthorized
+                  }
+                ]
+          ),
+        type_doc: "`http_credential | [http_credential]`",
+        doc: "Credentials for HTTP authentication. A credential map or a list of maps with `:username` and `:password`."
       ],
       ignore_https_errors: [
         type: :boolean,
@@ -115,11 +134,28 @@ defmodule PlaywrightEx.Browser do
   end
 
   defp prepare_new_context_opts(opts) do
-    case Keyword.fetch(opts, :viewport) do
-      {:ok, nil} ->
-        opts
-        |> Keyword.delete(:viewport)
-        |> Keyword.put(:no_default_viewport, true)
+    opts
+    |> prepare_viewport()
+    |> prepare_http_credentials()
+  end
+
+  defp prepare_viewport(opts) do
+    if Keyword.get(opts, :viewport) == nil and Keyword.has_key?(opts, :viewport) do
+      opts
+      |> Keyword.delete(:viewport)
+      |> Keyword.put(:no_default_viewport, true)
+    else
+      opts
+    end
+  end
+
+  defp prepare_http_credentials(opts) do
+    case Keyword.fetch(opts, :http_credentials) do
+      {:ok, credentials} when is_map(credentials) ->
+        Keyword.put(opts, :http_credentials, [credentials])
+
+      {:ok, []} ->
+        Keyword.delete(opts, :http_credentials)
 
       _ ->
         opts

--- a/lib/playwright_ex/channels/browser_context.ex
+++ b/lib/playwright_ex/channels/browser_context.ex
@@ -9,6 +9,40 @@ defmodule PlaywrightEx.BrowserContext do
 
   alias PlaywrightEx.ChannelResponse
   alias PlaywrightEx.Connection
+  alias PlaywrightEx.Serialization
+
+  schema =
+    NimbleOptions.new!(
+      connection: PlaywrightEx.Channel.connection_opt(),
+      timeout: PlaywrightEx.Channel.timeout_opt(),
+      event: [type: :atom, required: true],
+      enabled: [type: :boolean, default: true]
+    )
+
+  @doc """
+  Updates the subscription for browser-context events.
+
+  Playwright 1.63 adds the `:dialog_closed` event, emitted after a JavaScript
+  dialog is accepted, dismissed, or otherwise closed.
+
+  Reference: https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/client/browserContext.ts
+
+  ## Options
+  #{NimbleOptions.docs(schema)}
+  """
+  @schema schema
+  @type update_subscription_opt :: unquote(NimbleOptions.option_typespec(schema))
+  @spec update_subscription(PlaywrightEx.guid(), [update_subscription_opt() | PlaywrightEx.unknown_opt()]) ::
+          {:ok, any()} | {:error, any()}
+  def update_subscription(context_id, opts \\ []) do
+    {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
+    {timeout, opts} = Keyword.pop!(opts, :timeout)
+    params = opts |> Map.new() |> Map.update!(:event, &Serialization.camelize/1)
+
+    connection
+    |> Connection.send(%{guid: context_id, method: :update_subscription, params: params}, timeout)
+    |> ChannelResponse.unwrap(& &1)
+  end
 
   schema =
     NimbleOptions.new!(
@@ -357,11 +391,24 @@ defmodule PlaywrightEx.BrowserContext do
         Set to true to include IndexedDB in the storage state snapshot.
         If your application uses IndexedDB to store authentication tokens, like Firebase Authentication, enable this.
         """
+      ],
+      opfs: [
+        type: :boolean,
+        default: false,
+        doc: "Set to true to include the origin private file system in the storage state snapshot."
+      ],
+      credentials: [
+        type: :boolean,
+        default: false,
+        doc: "Set to true to include virtual WebAuthn credentials in the storage state snapshot."
       ]
     )
 
   @doc """
-  Returns storage state for this browser context, contains current cookies, local storage snapshot and IndexedDB snapshot.
+  Returns storage state for this browser context, including cookies and origin storage.
+
+  Origin storage can include local storage, IndexedDB, the origin private file
+  system, and virtual WebAuthn credentials according to the selected options.
 
   Reference: https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state
 
@@ -371,7 +418,7 @@ defmodule PlaywrightEx.BrowserContext do
   @schema schema
   @type storage_state_opt :: unquote(NimbleOptions.option_typespec(schema))
   @spec storage_state(PlaywrightEx.guid(), [storage_state_opt() | PlaywrightEx.unknown_opt()]) ::
-          {:ok, [map()]} | {:error, any()}
+          {:ok, map()} | {:error, any()}
   def storage_state(context_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
@@ -404,7 +451,11 @@ defmodule PlaywrightEx.BrowserContext do
     )
 
   @doc """
-  Clears the existing cookies, local storage and IndexedDB entries for all origins and sets the new storage state.
+  Clears the existing cookies and origin storage, then sets the new storage state.
+
+  Origin entries may contain local storage, IndexedDB, and `opfs` entries. Each
+  OPFS entry has a path, a `"file"` or `"directory"` type, and optional base64
+  content for files.
 
   Reference: https://playwright.dev/docs/api/class-browsercontext#browser-context-set-storage-state
 

--- a/lib/playwright_ex/channels/frame.ex
+++ b/lib/playwright_ex/channels/frame.ex
@@ -16,6 +16,49 @@ defmodule PlaywrightEx.Frame do
     NimbleOptions.new!(
       connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
+      mode: [
+        type: {:in, [:ai, :default]},
+        doc: "Snapshot representation mode."
+      ],
+      selector: [
+        type: :string,
+        doc: "Optional selector that scopes the snapshot."
+      ],
+      depth: [
+        type: :non_neg_integer,
+        doc: "Maximum depth of the returned accessibility tree."
+      ],
+      boxes: [
+        type: :boolean,
+        doc: "Whether to include element bounding boxes."
+      ]
+    )
+
+  @doc """
+  Returns an ARIA snapshot as structured JSON data.
+
+  Reference: https://playwright.dev/docs/api/class-page#page-aria-snapshot-json
+
+  ## Options
+  #{NimbleOptions.docs(schema)}
+  """
+  @schema schema
+  @type aria_snapshot_json_opt :: unquote(NimbleOptions.option_typespec(schema))
+  @spec aria_snapshot_json(PlaywrightEx.guid(), [aria_snapshot_json_opt() | PlaywrightEx.unknown_opt()]) ::
+          {:ok, any()} | {:error, any()}
+  def aria_snapshot_json(frame_id, opts \\ []) do
+    {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
+    {timeout, opts} = Keyword.pop!(opts, :timeout)
+
+    connection
+    |> Connection.send(%{guid: frame_id, method: :aria_snapshot_json, params: Map.new(opts)}, timeout)
+    |> ChannelResponse.unwrap(&Map.fetch!(&1, :snapshot))
+  end
+
+  schema =
+    NimbleOptions.new!(
+      connection: PlaywrightEx.Channel.connection_opt(),
+      timeout: PlaywrightEx.Channel.timeout_opt(),
       url: [
         type: :string,
         required: true,

--- a/lib/playwright_ex/channels/page.ex
+++ b/lib/playwright_ex/channels/page.ex
@@ -35,9 +35,10 @@ defmodule PlaywrightEx.Page do
   def update_subscription(page_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    params = opts |> Map.new() |> Map.update!(:event, &Serialization.camelize/1)
 
     connection
-    |> Connection.send(%{guid: page_id, method: :update_subscription, params: Map.new(opts)}, timeout)
+    |> Connection.send(%{guid: page_id, method: :update_subscription, params: params}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
 

--- a/lib/playwright_ex/channels/tracing.ex
+++ b/lib/playwright_ex/channels/tracing.ex
@@ -15,21 +15,30 @@ defmodule PlaywrightEx.Tracing do
     NimbleOptions.new!(
       connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
-      title: [
+      name: [
         type: :string,
-        doc: "Trace name to be shown in the Trace Viewer."
+        doc: "Trace name used for the generated trace files."
       ],
       screenshots: [
         type: :boolean,
-        doc: "Whether to capture screenshots during tracing"
+        doc: "Whether to capture a screencast during tracing."
       ],
       snapshots: [
-        type: :boolean,
-        doc: "Captures DOM snapshots and records network activity"
-      ],
-      sources: [
-        type: :boolean,
-        doc: "Whether to include source files for trace actions"
+        type: {:or, [:boolean, :map, :keyword_list]},
+        type_spec:
+          quote(
+            do:
+              boolean()
+              | %{
+                  optional(:dom) => boolean(),
+                  optional(:aria) => boolean(),
+                  optional(:screen) => boolean()
+                }
+              | keyword(boolean())
+          ),
+        type_doc: "`boolean | %{optional(:dom | :aria | :screen) => boolean} | keyword(boolean)`",
+        doc:
+          "Snapshot capture settings. A boolean controls DOM snapshots; a map or keyword list can configure `:dom`, `:aria`, and `:screen` separately."
       ]
     )
 
@@ -48,11 +57,40 @@ defmodule PlaywrightEx.Tracing do
   def tracing_start(tracing_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    params = tracing_start_params(opts)
 
     connection
-    |> Connection.send(%{guid: tracing_id, method: :tracing_start, params: Map.new(opts)}, timeout)
+    |> Connection.send(%{guid: tracing_id, method: :tracing_start, params: params}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
+
+  defp tracing_start_params(opts) do
+    {snapshots, opts} = Keyword.pop(opts, :snapshots)
+    {screenshots, opts} = Keyword.pop(opts, :screenshots)
+
+    opts
+    |> maybe_put(:screencast, screenshots)
+    |> put_snapshot_options(snapshots)
+    |> Map.new()
+  end
+
+  defp put_snapshot_options(opts, snapshots) when is_boolean(snapshots) do
+    Keyword.put(opts, :snapshot_dom, snapshots)
+  end
+
+  defp put_snapshot_options(opts, snapshots) when is_map(snapshots) or is_list(snapshots) do
+    Enum.reduce(snapshots, opts, fn
+      {:dom, value}, acc when is_boolean(value) -> Keyword.put(acc, :snapshot_dom, value)
+      {:aria, value}, acc when is_boolean(value) -> Keyword.put(acc, :snapshot_aria, value)
+      {:screen, value}, acc when is_boolean(value) -> Keyword.put(acc, :snapshot_screen, value)
+      option, _acc -> raise ArgumentError, "invalid tracing snapshot option: #{inspect(option)}"
+    end)
+  end
+
+  defp put_snapshot_options(opts, nil), do: opts
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
 
   schema =
     NimbleOptions.new!(

--- a/lib/playwright_ex/periphery/serialization.ex
+++ b/lib/playwright_ex/periphery/serialization.ex
@@ -4,6 +4,7 @@ defmodule PlaywrightEx.Serialization do
   def camelize(:inner_html), do: "innerHTML"
   def camelize(:base_url), do: "baseURL"
   def camelize(:ignore_https_errors), do: "ignoreHTTPSErrors"
+  def camelize(:aria_snapshot_json), do: "ariaSnapshotJSON"
   def camelize(input), do: input |> to_string() |> camelize(:lower)
   def underscore(string), do: string |> Macro.underscore() |> String.to_atom()
 

--- a/lib/playwright_ex/processes/port_transport.ex
+++ b/lib/playwright_ex/processes/port_transport.ex
@@ -111,10 +111,10 @@ defmodule PlaywrightEx.PortTransport do
   defp check_version(executable) do
     {"Version " <> version, 0} = executable |> Path.expand() |> System.cmd(~w(--version))
     version = version |> String.trim() |> Version.parse!()
-    recommended = PlaywrightEx.recommended_min_version()
+    minimum = PlaywrightEx.minimum_supported_version()
 
-    if Version.compare(version, recommended) == :lt do
-      IO.warn("Playwright version #{version} is below recommended #{recommended}")
+    if Version.compare(version, minimum) == :lt do
+      raise "Unsupported Playwright version #{version}; PlaywrightEx requires version #{minimum} or newer"
     end
   end
 end

--- a/lib/playwright_ex/processes/websocket_transport.ex
+++ b/lib/playwright_ex/processes/websocket_transport.ex
@@ -15,8 +15,8 @@ if Code.ensure_loaded?(WebSockex) do
 
     Run server via docker:
     ```bash
-    docker run -p 3000:3000 --rm --init -it mcr.microsoft.com/playwright:v1.58.0-noble \
-      npx -y playwright@1.58.0 run-server --port 3000 --host 0.0.0.0
+    docker run -p 3000:3000 --rm --init -it mcr.microsoft.com/playwright:v1.63.0-noble \
+      npx -y playwright@1.63.0 run-server --port 3000 --host 0.0.0.0
     ```
     """
     @behaviour PlaywrightEx.Transport

--- a/lib/playwright_ex/selector.ex
+++ b/lib/playwright_ex/selector.ex
@@ -39,6 +39,26 @@ defmodule PlaywrightEx.Selector do
   @spec has(t(), t()) :: t()
   def has(left, right), do: concat(left, "internal:has=#{JSON.encode!(right)}")
 
+  @doc """
+  Restricts a selector to visible or hidden elements.
+
+  This is the selector-building equivalent of Playwright 1.63's
+  `locator.visible()` API.
+  """
+  @spec visible(t()) :: t()
+  @spec visible(t(), boolean()) :: t()
+  def visible(selector, visible? \\ true), do: concat(selector, "visible=#{visible?}")
+
+  @doc """
+  Searches for a selector in any frame below the current frame.
+
+  This is the selector-building equivalent of calling Playwright 1.63's
+  `frameLocator()` without an iframe selector.
+  """
+  @spec any_frame(t()) :: t()
+  def any_frame(:none), do: :none
+  def any_frame(selector), do: concat("internal:control=any-frame", selector)
+
   @spec text(nil | String.t()) :: t()
   @spec text(nil | String.t(), exact_opts) :: t()
   def text(text, opts \\ [])

--- a/test/playwright_ex/browser_context_test.exs
+++ b/test/playwright_ex/browser_context_test.exs
@@ -2,6 +2,7 @@ defmodule PlaywrightEx.BrowserContextTest do
   use PlaywrightExCase, async: true
 
   alias PlaywrightEx.BrowserContext
+  alias PlaywrightEx.Dialog
   alias PlaywrightEx.Frame
 
   describe "add_init_script/2" do
@@ -73,6 +74,61 @@ defmodule PlaywrightEx.BrowserContextTest do
       elapsed = System.monotonic_time(:millisecond) - started_at
       assert before_now > 1_000_000
       assert after_now in 61_000..(61_000 + elapsed + 100)
+    end
+  end
+
+  describe "storage_state/2" do
+    test "accepts Playwright 1.63 OPFS storage snapshots", %{browser_context: browser_context} do
+      assert {:ok, %{cookies: [], origins: []}} =
+               BrowserContext.storage_state(browser_context.guid,
+                 indexedDB: true,
+                 opfs: true,
+                 credentials: true,
+                 timeout: @timeout
+               )
+    end
+  end
+
+  describe "dialog_closed events" do
+    test "subscribes on the browser context", %{browser_context: browser_context, frame: frame} do
+      :ok = PlaywrightEx.subscribe(browser_context.guid)
+
+      on_exit(fn ->
+        PlaywrightEx.unsubscribe(browser_context.guid)
+      end)
+
+      assert {:ok, _} =
+               BrowserContext.update_subscription(browser_context.guid,
+                 event: :dialog,
+                 timeout: @timeout
+               )
+
+      assert {:ok, _} =
+               BrowserContext.update_subscription(browser_context.guid,
+                 event: :dialog_closed,
+                 timeout: @timeout
+               )
+
+      evaluation = Task.async(fn -> eval(frame.guid, "() => alert('closed')") end)
+
+      assert_receive {:playwright_msg,
+                      %{
+                        guid: context_id,
+                        method: :dialog,
+                        params: %{dialog: %{guid: dialog_id}}
+                      }}
+
+      assert context_id == browser_context.guid
+      assert {:ok, _} = Dialog.accept(dialog_id, timeout: @timeout)
+
+      assert_receive {:playwright_msg,
+                      %{
+                        guid: ^context_id,
+                        method: :dialog_closed,
+                        params: %{dialog: %{guid: ^dialog_id}}
+                      }}
+
+      assert {:ok, nil} = Task.await(evaluation)
     end
   end
 end

--- a/test/playwright_ex/browser_test.exs
+++ b/test/playwright_ex/browser_test.exs
@@ -15,5 +15,24 @@ defmodule PlaywrightEx.BrowserTest do
     test "no default viewport", %{browser: browser} do
       assert {:ok, _} = Browser.new_context(browser.guid, viewport: nil, timeout: @timeout)
     end
+
+    test "normalizes one HTTP credential to the Playwright 1.63 protocol array", %{browser: browser} do
+      assert {:ok, _} =
+               Browser.new_context(browser.guid,
+                 http_credentials: %{username: "user", password: "password"},
+                 timeout: @timeout
+               )
+    end
+
+    test "accepts multiple origin-specific HTTP credentials", %{browser: browser} do
+      assert {:ok, _} =
+               Browser.new_context(browser.guid,
+                 http_credentials: [
+                   %{username: "one", password: "first", origin: "https://one.example"},
+                   %{username: "two", password: "second", origin: "https://two.example", send: :always}
+                 ],
+                 timeout: @timeout
+               )
+    end
   end
 end

--- a/test/playwright_ex/frame_test.exs
+++ b/test/playwright_ex/frame_test.exs
@@ -154,6 +154,37 @@ defmodule PlaywrightEx.FrameTest do
       assert {:ok, true} = Frame.is_visible(frame.guid, selector: "#visible", timeout: @timeout)
       assert {:ok, false} = Frame.is_visible(frame.guid, selector: "#hidden", timeout: @timeout)
     end
+
+    test "visible selector filters hidden matches", %{frame: frame} do
+      set_html(frame.guid, """
+      <button class="item" style="display:none">Hidden</button>
+      <button class="item">Visible</button>
+      """)
+
+      selector = ".item" |> Selector.css() |> Selector.visible()
+
+      assert {:ok, "Visible"} = Frame.inner_text(frame.guid, selector: selector, timeout: @timeout)
+    end
+  end
+
+  describe "aria_snapshot_json/2" do
+    test "returns a structured accessibility snapshot", %{frame: frame} do
+      set_html(frame.guid, "<main><button>Save changes</button></main>")
+
+      assert {:ok, snapshot} = Frame.aria_snapshot_json(frame.guid, mode: :default, boxes: true, timeout: @timeout)
+      assert is_list(snapshot)
+      assert inspect(snapshot) =~ "Save changes"
+    end
+  end
+
+  describe "cross-frame selectors" do
+    test "finds an element in any descendant frame", %{frame: frame} do
+      set_html(frame.guid, ~s(<iframe srcdoc="<button>Inside frame</button>"></iframe>))
+      selector = Selector.any_frame(Selector.button("Inside frame"))
+
+      assert {:ok, _} = Frame.wait_for_selector(frame.guid, selector: selector, timeout: @timeout)
+      assert {:ok, "Inside frame"} = Frame.inner_text(frame.guid, selector: selector, timeout: @timeout)
+    end
   end
 
   describe "is_checked/2" do

--- a/test/playwright_ex/processes/port_transport_test.exs
+++ b/test/playwright_ex/processes/port_transport_test.exs
@@ -1,0 +1,18 @@
+defmodule PlaywrightEx.PortTransportTest do
+  use ExUnit.Case, async: true
+
+  alias PlaywrightEx.PortTransport
+
+  @tag :tmp_dir
+  test "rejects Playwright versions older than 1.63", %{tmp_dir: tmp_dir} do
+    executable = Path.join(tmp_dir, "playwright")
+    File.write!(executable, "#!/bin/sh\nprintf 'Version 1.62.1\\n'\n")
+    File.chmod!(executable, 0o755)
+
+    assert_raise RuntimeError,
+                 "Unsupported Playwright version 1.62.1; PlaywrightEx requires version 1.63.0 or newer",
+                 fn ->
+                   PortTransport.start_link(executable: executable)
+                 end
+  end
+end

--- a/test/playwright_ex/tracing_test.exs
+++ b/test/playwright_ex/tracing_test.exs
@@ -8,6 +8,31 @@ defmodule PlaywrightEx.TracingTest do
     [tracing_id: context.browser_context.tracing.guid]
   end
 
+  describe "tracing_start/2" do
+    test "captures Playwright 1.63 DOM, ARIA, screen, and screencast snapshots", %{
+      tracing_id: tracing_id,
+      frame: frame
+    } do
+      {:ok, _} =
+        Tracing.tracing_start(tracing_id,
+          snapshots: %{dom: true, aria: true, screen: true},
+          screenshots: true,
+          timeout: @timeout
+        )
+
+      {:ok, _} = Tracing.tracing_start_chunk(tracing_id, timeout: @timeout)
+      set_html(frame.guid, "<button>Trace me</button>")
+      {:ok, _} = Frame.click(frame.guid, selector: "button", timeout: @timeout)
+
+      trace = stop_tracing(tracing_id)
+
+      assert trace =~ ~s("type":"frame-snapshot")
+      assert trace =~ ~s("type":"aria-snapshot")
+      assert trace =~ ~s("type":"screenshot")
+      assert trace =~ ~s("type":"screencast-frame")
+    end
+  end
+
   describe "group/3" do
     test "writes name and location with nesting", %{tracing_id: tracing_id, frame: frame} do
       start_tracing(tracing_id)

--- a/test/playwright_ex_test.exs
+++ b/test/playwright_ex_test.exs
@@ -42,7 +42,13 @@ defmodule PlaywrightExTest do
   end
 
   def on_exit_open_trace(tracing_id, tmp_dir, timeout) do
-    {:ok, _} = Tracing.tracing_start(tracing_id, screenshots: true, snapshots: true, sources: true, timeout: timeout)
+    {:ok, _} =
+      Tracing.tracing_start(tracing_id,
+        screenshots: true,
+        snapshots: %{dom: true, aria: true, screen: true},
+        timeout: timeout
+      )
+
     {:ok, _} = Tracing.tracing_start_chunk(tracing_id, timeout: timeout)
 
     ExUnit.Callbacks.on_exit(fn ->


### PR DESCRIPTION
## Summary
- require Playwright 1.63+ and reject older local drivers
- adapt HTTP credentials and tracing to the 1.63 wire contract
- expose OPFS storage state, structured ARIA snapshots, dialog-closed events, visible-only selectors, and cross-frame selectors
- update documentation and add protocol regression coverage

## Verification
- `mix check` (127 tests; formatting, Credo, compilation, and Dialyzer all pass)
- local port transport exercised with Playwright 1.63.0
- WebSocket suite could not be started locally because this host has no Docker socket; CI covers both port and WebSocket transports