### PR TITLE
Round-trip Playwright 1.63 storage state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Map the public tracing snapshot and screenshot options to Playwright 1.63's
   `snapshotDom`, `snapshotAria`, `snapshotScreen`, and `screencast` wire fields.
 
+### Fixed
+- Allow `BrowserContext.set_storage_state/2` to restore virtual WebAuthn
+  credentials, and cover OPFS state capture and restoration with a round-trip
+  regression test.
+
 ## [0.8.0] 2026-08-27
 ### Changed
 - Require Playwright 1.62 or newer. Command timeouts are now sent as protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Allow `BrowserContext.set_storage_state/2` to restore virtual WebAuthn
-  credentials, and cover OPFS state capture and restoration with a round-trip
-  regression test.
+  credentials, and cover OPFS and credential state capture and restoration with
+  round-trip regression tests.
 
 ## [0.8.0] 2026-08-27
 ### Changed

--- a/lib/playwright_ex/channels/browser_context.ex
+++ b/lib/playwright_ex/channels/browser_context.ex
@@ -447,6 +447,10 @@ defmodule PlaywrightEx.BrowserContext do
         List of origins and their local storage to set as the current local storage data on the context.
         Defaults to an empty list to clear all local storage on the context.
         """
+      ],
+      credentials: [
+        type: {:list, :map},
+        doc: "List of virtual WebAuthn credentials to restore into the context."
       ]
     )
 
@@ -455,7 +459,8 @@ defmodule PlaywrightEx.BrowserContext do
 
   Origin entries may contain local storage, IndexedDB, and `opfs` entries. Each
   OPFS entry has a path, a `"file"` or `"directory"` type, and optional base64
-  content for files.
+  content for files. The storage state may also contain virtual WebAuthn
+  `credentials`.
 
   Reference: https://playwright.dev/docs/api/class-browsercontext#browser-context-set-storage-state
 

--- a/test/playwright_ex/browser_context_test.exs
+++ b/test/playwright_ex/browser_context_test.exs
@@ -78,14 +78,30 @@ defmodule PlaywrightEx.BrowserContextTest do
   end
 
   describe "storage_state/2" do
-    test "accepts Playwright 1.63 OPFS storage snapshots", %{browser_context: browser_context} do
-      assert {:ok, %{cookies: [], origins: []}} =
+    test "restores and captures Playwright 1.63 OPFS storage snapshots", %{browser_context: browser_context} do
+      origin = "https://playwright.example"
+
+      opfs = [
+        %{path: "nested", type: "directory"},
+        %{path: "nested/state.txt", type: "file", base64: Base.encode64("persisted state")}
+      ]
+
+      assert {:ok, _} =
+               BrowserContext.set_storage_state(browser_context.guid,
+                 origins: [%{origin: origin, local_storage: [], opfs: opfs}],
+                 credentials: [],
+                 timeout: @timeout
+               )
+
+      assert {:ok, %{cookies: [], credentials: [], origins: [stored_origin]}} =
                BrowserContext.storage_state(browser_context.guid,
                  indexedDB: true,
                  opfs: true,
                  credentials: true,
                  timeout: @timeout
                )
+
+      assert %{origin: ^origin, local_storage: [], indexed_db: [], opfs: ^opfs} = stored_origin
     end
   end
 

--- a/test/playwright_ex/browser_context_test.exs
+++ b/test/playwright_ex/browser_context_test.exs
@@ -103,6 +103,30 @@ defmodule PlaywrightEx.BrowserContextTest do
 
       assert %{origin: ^origin, local_storage: [], indexed_db: [], opfs: ^opfs} = stored_origin
     end
+
+    test "restores and captures virtual WebAuthn credentials", %{browser_context: browser_context} do
+      credential = %{
+        id: "Y3JlZGVudGlhbC1pZA",
+        rp_id: "playwright.example",
+        user_handle: "dXNlci1oYW5kbGU",
+        private_key:
+          "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgd7APaIOC9SaWeXcnLaJvUwOtVFRIJEtAn7_XRNca-iehRANCAAR_QQZB2zOOZQEFMYs7F3fzikNpyFXuoNPyyqiJrhEpRrH4DgSS0IofC3rz5UiguK1yHJ_bh-hhSHA1lEQQO57j",
+        public_key:
+          "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEf0EGQdszjmUBBTGLOxd384pDachV7qDT8sqoia4RKUax-A4EktCKHwt68-VIoLitchyf24foYUhwNZREEDue4w"
+      }
+
+      assert {:ok, _} =
+               BrowserContext.set_storage_state(browser_context.guid,
+                 credentials: [credential],
+                 timeout: @timeout
+               )
+
+      assert {:ok, %{credentials: [^credential]}} =
+               BrowserContext.storage_state(browser_context.guid,
+                 credentials: true,
+                 timeout: @timeout
+               )
+    end
   end
 
   describe "dialog_closed events" do


### PR DESCRIPTION
## Summary
- accept virtual WebAuthn credentials in `BrowserContext.set_storage_state/2`
- replace the empty OPFS smoke test with a capture-and-restore round trip
- document restored credentials and the regression fix

## Verification
- `mise exec -- mix test test/playwright_ex/browser_context_test.exs` (7 tests)
- `mise exec -- mix check` (127 tests; formatting, Credo, compilation, and Dialyzer pass)