### PR TITLE
Fix full Playwright 1.63 protocol alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   map or a list.
 - Map the public tracing snapshot and screenshot options to Playwright 1.63's
   `snapshotDom`, `snapshotAria`, `snapshotScreen`, and `screencast` wire fields.
+- Use Playwright 1.63 as the sole protocol baseline. Remote connections now
+  advertise that version during the WebSocket handshake and restart the full
+  connection state after a disconnect instead of reusing stale channel state.
 
 ### Fixed
+- Align every implemented channel operation with the Playwright 1.63 wire
+  contract, including browser context enums and HTTP headers, browser launch
+  environment and signal fields, cookie filters and SameSite values, storage
+  state credentials, frame selection and polling, subscription events, and all
+  tracing stop modes.
+- Correlate the root `initialize` request, track `__create__`/`__adopt__`
+  ownership, recursively dispose child channels, and associate frame waiters
+  with their page from `Page.mainFrame`. Console and page-error events are now
+  both logged and delivered to subscribers.
+- Support all Playwright 1.63 serialized-value variants, preserve opaque JSON
+  keys, and avoid creating atoms from untrusted protocol keys.
+- Handle omitted void results and protocol call logs, buffer fragmented port
+  frame headers correctly, keep Node stderr out of protocol framing, and close
+  remote artifact streams after read failures.
+
 - Allow `BrowserContext.set_storage_state/2` to restore virtual WebAuthn
   credentials, and cover OPFS and credential state capture and restoration with
   round-trip regression tests.

--- a/lib/playwright_ex/artifact.ex
+++ b/lib/playwright_ex/artifact.ex
@@ -71,10 +71,28 @@ defmodule PlaywrightEx.Artifact do
     with {:ok, %{stream: %{guid: stream_guid}}} <-
            connection
            |> Connection.send(%{guid: artifact_guid, method: :save_as_stream, params: %{}}, timeout)
-           |> ChannelResponse.unwrap(& &1),
-         :ok <- stream_to_file(connection, stream_guid, timeout, path),
-         {:ok, _} <- close_stream(connection, stream_guid, timeout) do
-      :ok
+           |> ChannelResponse.unwrap(& &1) do
+      stream_result = stream_to_file_and_close(connection, stream_guid, timeout, path)
+      stream_result
+    end
+  end
+
+  defp stream_to_file_and_close(connection, stream_guid, timeout, path) do
+    stream_result =
+      try do
+        stream_to_file(connection, stream_guid, timeout, path)
+      catch
+        kind, reason ->
+          _ = close_stream(connection, stream_guid, timeout)
+          :erlang.raise(kind, reason, __STACKTRACE__)
+      end
+
+    close_result = close_stream(connection, stream_guid, timeout)
+
+    case {stream_result, close_result} do
+      {:ok, {:ok, _}} -> :ok
+      {{:error, _} = error, _close_result} -> error
+      {:ok, {:error, _} = error} -> error
     end
   end
 

--- a/lib/playwright_ex/channels/browser.ex
+++ b/lib/playwright_ex/channels/browser.ex
@@ -28,7 +28,7 @@ defmodule PlaywrightEx.Browser do
         doc: "Toggles bypassing page's Content-Security-Policy. Defaults to `false`."
       ],
       color_scheme: [
-        type: {:in, [:light, :dark, :no_preference, :null]},
+        type: {:in, [:light, :dark, :no_preference, :no_override, :null]},
         doc: "Emulates `'prefers-colors-scheme'` media feature. Defaults to `:light`."
       ],
       device_scale_factor: [
@@ -36,7 +36,14 @@ defmodule PlaywrightEx.Browser do
         doc: "Specify device scale factor (can be thought of as dpr). Defaults to `1`."
       ],
       extra_http_headers: [
-        type: :any,
+        type: {:or, [{:map, {:or, [:atom, :string]}, :any}, {:list, :map}]},
+        type_spec:
+          quote(
+            do:
+              %{optional(String.t()) => String.t()}
+              | [%{required(:name) => String.t(), required(:value) => String.t()}]
+          ),
+        type_doc: "`%{header => value} | [%{name: header, value: value}]`",
         doc: "An object containing additional HTTP headers to be sent with every request."
       ],
       http_credentials: [
@@ -137,6 +144,9 @@ defmodule PlaywrightEx.Browser do
     opts
     |> prepare_viewport()
     |> prepare_http_credentials()
+    |> prepare_accept_downloads()
+    |> prepare_color_scheme()
+    |> prepare_extra_http_headers()
   end
 
   defp prepare_viewport(opts) do
@@ -156,6 +166,34 @@ defmodule PlaywrightEx.Browser do
 
       {:ok, []} ->
         Keyword.delete(opts, :http_credentials)
+
+      _ ->
+        opts
+    end
+  end
+
+  defp prepare_accept_downloads(opts) do
+    case Keyword.fetch(opts, :accept_downloads) do
+      {:ok, true} -> Keyword.put(opts, :accept_downloads, "accept")
+      {:ok, false} -> Keyword.put(opts, :accept_downloads, "deny")
+      :error -> opts
+    end
+  end
+
+  defp prepare_color_scheme(opts) do
+    case Keyword.fetch(opts, :color_scheme) do
+      {:ok, :no_preference} -> Keyword.put(opts, :color_scheme, "no-preference")
+      {:ok, value} when value in [:null, :no_override] -> Keyword.put(opts, :color_scheme, "no-override")
+      :error -> opts
+      _ -> opts
+    end
+  end
+
+  defp prepare_extra_http_headers(opts) do
+    case Keyword.fetch(opts, :extra_http_headers) do
+      {:ok, headers} when is_map(headers) ->
+        normalized = Enum.map(headers, fn {name, value} -> %{name: to_string(name), value: to_string(value)} end)
+        Keyword.put(opts, :extra_http_headers, normalized)
 
       _ ->
         opts

--- a/lib/playwright_ex/channels/browser_context.ex
+++ b/lib/playwright_ex/channels/browser_context.ex
@@ -15,7 +15,10 @@ defmodule PlaywrightEx.BrowserContext do
     NimbleOptions.new!(
       connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
-      event: [type: :atom, required: true],
+      event: [
+        type: {:in, [:console, :dialog, :dialog_closed, :request, :response, :request_finished, :request_failed]},
+        required: true
+      ],
       enabled: [type: :boolean, default: true]
     )
 
@@ -97,11 +100,24 @@ defmodule PlaywrightEx.BrowserContext do
   def add_cookies(context_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    opts = Keyword.update!(opts, :cookies, &Enum.map(&1, fn cookie -> normalize_cookie(cookie) end))
 
     connection
     |> Connection.send(%{guid: context_id, method: :add_cookies, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
+
+  defp normalize_cookie(%{} = cookie) do
+    case Map.fetch(cookie, :same_site) do
+      {:ok, value} -> Map.put(cookie, :same_site, normalize_same_site(value))
+      :error -> cookie
+    end
+  end
+
+  defp normalize_same_site(value) when value in [:strict, "strict"], do: "Strict"
+  defp normalize_same_site(value) when value in [:lax, "lax"], do: "Lax"
+  defp normalize_same_site(value) when value in [:none, "none"], do: "None"
+  defp normalize_same_site(value), do: value
 
   schema =
     NimbleOptions.new!(
@@ -140,17 +156,17 @@ defmodule PlaywrightEx.BrowserContext do
       connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
       domain: [
-        type: :any,
+        type: {:or, [:string, {:struct, Regex}]},
         required: false,
         doc: "Only removes cookies with the given domain."
       ],
       name: [
-        type: :any,
+        type: {:or, [:string, {:struct, Regex}]},
         required: false,
         doc: "Only removes cookies with the given name."
       ],
       path: [
-        type: :any,
+        type: {:or, [:string, {:struct, Regex}]},
         required: false,
         doc: "Only removes cookies with the given path."
       ]
@@ -171,11 +187,31 @@ defmodule PlaywrightEx.BrowserContext do
   def clear_cookies(context_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    opts = Enum.reduce([:name, :domain, :path], opts, &prepare_cookie_filter/2)
 
     connection
     |> Connection.send(%{guid: context_id, method: :clear_cookies, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
+
+  defp prepare_cookie_filter(field, opts) do
+    case Keyword.fetch(opts, field) do
+      {:ok, %Regex{source: source, opts: regex_opts}} ->
+        {source_field, flags_field} = cookie_regex_fields(field)
+
+        opts
+        |> Keyword.delete(field)
+        |> Keyword.put(source_field, source)
+        |> Keyword.put(flags_field, Serialization.regex_flags_for_protocol(regex_opts))
+
+      _ ->
+        opts
+    end
+  end
+
+  defp cookie_regex_fields(:name), do: {:name_regex_source, :name_regex_flags}
+  defp cookie_regex_fields(:domain), do: {:domain_regex_source, :domain_regex_flags}
+  defp cookie_regex_fields(:path), do: {:path_regex_source, :path_regex_flags}
 
   schema =
     NimbleOptions.new!(
@@ -292,7 +328,7 @@ defmodule PlaywrightEx.BrowserContext do
     {timeout, opts} = Keyword.pop!(opts, :timeout)
 
     connection
-    |> Connection.send(%{guid: context_id, method: :addInitScript, params: Map.new(opts)}, timeout)
+    |> Connection.send(%{guid: context_id, method: :add_init_script, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
 
@@ -384,7 +420,7 @@ defmodule PlaywrightEx.BrowserContext do
     NimbleOptions.new!(
       connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
-      indexedDB: [
+      indexed_db: [
         type: :boolean,
         default: false,
         doc: """
@@ -476,7 +512,7 @@ defmodule PlaywrightEx.BrowserContext do
     {timeout, opts} = Keyword.pop!(opts, :timeout)
 
     connection
-    |> Connection.send(%{guid: context_id, method: :set_storage_state, params: %{storageState: Map.new(opts)}}, timeout)
+    |> Connection.send(%{guid: context_id, method: :set_storage_state, params: %{storage_state: Map.new(opts)}}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
 end

--- a/lib/playwright_ex/channels/browser_type.ex
+++ b/lib/playwright_ex/channels/browser_type.ex
@@ -20,14 +20,43 @@ defmodule PlaywrightEx.BrowserType do
         type: :string,
         doc: "Browser distribution channel."
       ],
+      args: [
+        type: {:list, :string},
+        doc: "Additional command-line arguments passed to the browser."
+      ],
       executable_path: [
         type: :string,
         doc: "Path to a browser executable to run instead of the bundled one."
+      ],
+      ignore_all_default_args: [
+        type: :boolean,
+        doc: "Whether to omit all Playwright default browser arguments."
+      ],
+      ignore_default_args: [
+        type: {:list, :string},
+        doc: "Specific Playwright default browser arguments to omit."
+      ],
+      handle_sigint: [type: :boolean, doc: "Whether Playwright handles SIGINT."],
+      handle_sigterm: [type: :boolean, doc: "Whether Playwright handles SIGTERM."],
+      handle_sighup: [type: :boolean, doc: "Whether Playwright handles SIGHUP."],
+      env: [
+        type: {:or, [{:map, {:or, [:atom, :string]}, :any}, {:list, :map}]},
+        doc: "Environment variables as a map or Playwright name/value entries."
       ],
       headless: [
         type: :boolean,
         doc: "Whether to run browser in headless mode."
       ],
+      proxy: [type: :map, doc: "Proxy settings for the browser process."],
+      downloads_path: [type: :string, doc: "Directory in which to place downloads."],
+      traces_dir: [type: :string, doc: "Directory in which to place tracing data."],
+      artifacts_dir: [type: :string, doc: "Directory in which to place browser artifacts."],
+      chromium_sandbox: [type: :boolean, doc: "Whether Chromium sandboxing is enabled."],
+      firefox_user_prefs: [
+        type: {:map, {:or, [:atom, :string]}, :any},
+        doc: "Firefox preferences, preserved as an opaque JSON object."
+      ],
+      cdp_port: [type: :non_neg_integer, doc: "Chrome DevTools Protocol port."],
       slow_mo: [
         type: {:or, [:integer, :float]},
         doc: "Slows down Playwright operations by the specified amount of milliseconds."
@@ -49,10 +78,21 @@ defmodule PlaywrightEx.BrowserType do
   def launch(type_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    opts = prepare_launch_opts(opts)
 
     connection
     |> Connection.send(%{guid: type_id, method: :launch, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap_create(:browser, connection)
+  end
+
+  defp prepare_launch_opts(opts) do
+    case Keyword.fetch(opts, :env) do
+      {:ok, env} when is_map(env) ->
+        Keyword.put(opts, :env, Enum.map(env, fn {name, value} -> %{name: to_string(name), value: to_string(value)} end))
+
+      _ ->
+        opts
+    end
   end
 
   @doc false

--- a/lib/playwright_ex/channels/frame.ex
+++ b/lib/playwright_ex/channels/frame.ex
@@ -523,11 +523,45 @@ defmodule PlaywrightEx.Frame do
   def select_option(frame_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    {values, opts} = Keyword.pop!(opts, :options)
+    opts = Keyword.merge(opts, normalize_select_options(values))
 
     connection
     |> Connection.send(%{guid: frame_id, method: :select_option, params: Map.new(opts)}, timeout)
-    |> ChannelResponse.unwrap(& &1)
+    |> ChannelResponse.unwrap(& &1.values)
   end
+
+  defp normalize_select_options(nil), do: []
+  defp normalize_select_options([]), do: []
+
+  defp normalize_select_options(value) when not is_list(value) do
+    normalize_select_options([value])
+  end
+
+  defp normalize_select_options(values) do
+    {elements, options} =
+      Enum.reduce(values, {[], []}, fn
+        %{guid: guid} = element, {elements, options} when is_binary(guid) ->
+          {[element | elements], options}
+
+        value, {elements, options} when is_binary(value) ->
+          {elements, [%{value_or_label: value} | options]}
+
+        %{} = option, {elements, options} ->
+          {elements, [option | options]}
+
+        value, _acc ->
+          raise ArgumentError,
+                "expected each select option to be a string, descriptor map, or element handle, got: #{inspect(value)}"
+      end)
+
+    []
+    |> maybe_put_select_values(:elements, Enum.reverse(elements))
+    |> maybe_put_select_values(:options, Enum.reverse(options))
+  end
+
+  defp maybe_put_select_values(opts, _key, []), do: opts
+  defp maybe_put_select_values(opts, key, values), do: Keyword.put(opts, key, values)
 
   schema =
     NimbleOptions.new!(
@@ -1191,7 +1225,7 @@ defmodule PlaywrightEx.Frame do
         doc: "Optional argument to pass to the function."
       ],
       polling: [
-        type: {:or, [:pos_integer, :string]},
+        type: {:or, [:pos_integer, {:in, ["raf"]}]},
         default: "raf",
         doc: "Polling interval in ms, or `\"raf\"` for requestAnimationFrame."
       ]
@@ -1215,9 +1249,11 @@ defmodule PlaywrightEx.Frame do
   def wait_for_function(frame_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    {polling, opts} = Keyword.pop!(opts, :polling)
 
     params =
       opts
+      |> maybe_put_polling_interval(polling)
       |> Map.new()
       |> Map.update!(:arg, &Serialization.serialize_arg/1)
 
@@ -1225,6 +1261,11 @@ defmodule PlaywrightEx.Frame do
     |> Connection.send(%{guid: frame_id, method: :wait_for_function, params: params}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
+
+  defp maybe_put_polling_interval(opts, "raf"), do: opts
+
+  defp maybe_put_polling_interval(opts, interval) when is_integer(interval),
+    do: Keyword.put(opts, :polling_interval, interval)
 
   schema =
     NimbleOptions.new!(

--- a/lib/playwright_ex/channels/page.ex
+++ b/lib/playwright_ex/channels/page.ex
@@ -16,7 +16,12 @@ defmodule PlaywrightEx.Page do
     NimbleOptions.new!(
       connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
-      event: [type: :atom, required: true],
+      event: [
+        type:
+          {:in,
+           [:console, :dialog, :dialog_closed, :file_chooser, :request, :response, :request_finished, :request_failed]},
+        required: true
+      ],
       enabled: [type: :boolean, default: true]
     )
 
@@ -121,7 +126,7 @@ defmodule PlaywrightEx.Page do
     )
 
   @doc """
-  Returns a screenshot of the page as binary data.
+  Returns the screenshot as a base64-encoded binary string.
 
   Reference: https://playwright.dev/docs/api/class-page#page-screenshot
 
@@ -192,7 +197,7 @@ defmodule PlaywrightEx.Page do
     {timeout, opts} = Keyword.pop!(opts, :timeout)
 
     connection
-    |> Connection.send(%{guid: page_id, method: :mouseMove, params: Map.new(opts)}, timeout)
+    |> Connection.send(%{guid: page_id, method: :mouse_move, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
 
@@ -232,7 +237,7 @@ defmodule PlaywrightEx.Page do
     {timeout, opts} = Keyword.pop!(opts, :timeout)
 
     connection
-    |> Connection.send(%{guid: page_id, method: :mouseDown, params: Map.new(opts)}, timeout)
+    |> Connection.send(%{guid: page_id, method: :mouse_down, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
 
@@ -270,7 +275,7 @@ defmodule PlaywrightEx.Page do
     {timeout, opts} = Keyword.pop!(opts, :timeout)
 
     connection
-    |> Connection.send(%{guid: page_id, method: :mouseUp, params: Map.new(opts)}, timeout)
+    |> Connection.send(%{guid: page_id, method: :mouse_up, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
 
@@ -376,7 +381,7 @@ defmodule PlaywrightEx.Page do
     {timeout, opts} = Keyword.pop!(opts, :timeout)
 
     connection
-    |> Connection.send(%{guid: context_id, method: :addInitScript, params: Map.new(opts)}, timeout)
+    |> Connection.send(%{guid: context_id, method: :add_init_script, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1)
   end
 
@@ -415,7 +420,7 @@ defmodule PlaywrightEx.Page do
       connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
       is_not: [type: :boolean, default: false],
-      expected: [type: :any, doc: "Baseline PNG binary. `nil` = capture-only mode."],
+      expected: [type: :any, doc: "Base64-encoded baseline image. `nil` = capture-only mode."],
       comparator: [type: {:in, ["pixelmatch", "ssim-cie94"]}, default: "pixelmatch"],
       max_diff_pixels: [type: :integer, doc: "Max absolute pixel count allowed to differ."],
       max_diff_pixel_ratio: [type: :float, doc: "Max ratio (0-1) of differing pixels."],
@@ -453,9 +458,10 @@ defmodule PlaywrightEx.Page do
   def expect_screenshot(page_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    opts = if Keyword.get(opts, :expected) == nil, do: Keyword.delete(opts, :expected), else: opts
 
     connection
-    |> Connection.send(%{guid: page_id, method: :expectScreenshot, params: Map.new(opts)}, timeout)
+    |> Connection.send(%{guid: page_id, method: :expect_screenshot, params: Map.new(opts)}, timeout)
     |> ChannelResponse.unwrap(& &1[:actual])
     |> case do
       {:ok, result} -> {:ok, result}

--- a/lib/playwright_ex/channels/tracing.ex
+++ b/lib/playwright_ex/channels/tracing.ex
@@ -154,7 +154,7 @@ defmodule PlaywrightEx.Tracing do
       connection: PlaywrightEx.Channel.connection_opt(),
       timeout: PlaywrightEx.Channel.timeout_opt(),
       mode: [
-        type: :atom,
+        type: {:in, [:archive, :discard, :entries]},
         doc: "Mode for stopping the chunk",
         default: :archive
       ]
@@ -171,17 +171,30 @@ defmodule PlaywrightEx.Tracing do
   @schema schema
   @type stop_chunk_opt :: unquote(NimbleOptions.option_typespec(schema))
   @spec tracing_stop_chunk(PlaywrightEx.guid(), [stop_chunk_opt() | PlaywrightEx.unknown_opt()]) ::
-          {:ok, %{guid: PlaywrightEx.guid(), absolute_path: Path.t()}} | {:error, any()}
+          {:ok, %{guid: PlaywrightEx.guid(), absolute_path: Path.t()} | [map()] | nil} | {:error, any()}
   def tracing_stop_chunk(tracing_id, opts \\ []) do
     {connection, opts} = opts |> PlaywrightEx.Channel.validate_known!(@schema) |> Keyword.pop!(:connection)
     {timeout, opts} = Keyword.pop!(opts, :timeout)
+    mode = Keyword.fetch!(opts, :mode)
 
-    with {:ok, artifact} <-
+    with {:ok, result} <-
            connection
            |> Connection.send(%{guid: tracing_id, method: :tracing_stop_chunk, params: Map.new(opts)}, timeout)
-           |> ChannelResponse.unwrap_create(:artifact, connection) do
-      maybe_download_artifact(connection, artifact, timeout)
+           |> ChannelResponse.unwrap(& &1) do
+      handle_stop_chunk_result(mode, result, connection, timeout)
     end
+  end
+
+  defp handle_stop_chunk_result(:discard, _result, _connection, _timeout), do: {:ok, nil}
+  defp handle_stop_chunk_result(:entries, result, _connection, _timeout), do: {:ok, Map.get(result, :entries, [])}
+  defp handle_stop_chunk_result(:archive, %{artifact: nil}, _connection, _timeout), do: {:ok, nil}
+
+  defp handle_stop_chunk_result(:archive, result, _connection, _timeout) when not is_map_key(result, :artifact),
+    do: {:ok, nil}
+
+  defp handle_stop_chunk_result(:archive, %{artifact: artifact}, connection, timeout) do
+    artifact = Map.merge(artifact, Connection.initializer!(connection, artifact.guid))
+    maybe_download_artifact(connection, artifact, timeout)
   end
 
   defp maybe_download_artifact(connection, artifact, timeout) do

--- a/lib/playwright_ex/periphery/channel_response.ex
+++ b/lib/playwright_ex/periphery/channel_response.ex
@@ -4,9 +4,13 @@ defmodule PlaywrightEx.ChannelResponse do
   alias PlaywrightEx.Connection
 
   @spec unwrap(any(), (any() -> result)) :: {:ok, result} | {:error, any()} when result: any()
-  def unwrap(%{error: %{} = error, error_details: details}, _), do: {:error, {error, details}}
-  def unwrap(%{error: error}, _), do: {:error, error}
+  def unwrap(%{error: %{} = error, error_details: details} = response, _) do
+    {:error, {maybe_attach_log(error, response), details}}
+  end
+
+  def unwrap(%{error: error} = response, _), do: {:error, maybe_attach_log(error, response)}
   def unwrap(%{result: result}, fun) when is_function(fun, 1), do: {:ok, fun.(result)}
+  def unwrap(%{id: _id}, fun) when is_function(fun, 1), do: {:ok, fun.(%{})}
   def unwrap(other, fun) when is_function(fun, 1), do: {:ok, other}
 
   @spec unwrap_create(any(), atom(), GenServer.name()) :: {:ok, any()} | {:error, any()}
@@ -16,4 +20,7 @@ defmodule PlaywrightEx.ChannelResponse do
       Map.merge(resource, Connection.initializer!(connection, resource.guid))
     end)
   end
+
+  defp maybe_attach_log(%{} = error, %{log: log}) when is_list(log) and log != [], do: Map.put(error, :log, log)
+  defp maybe_attach_log(error, _response), do: error
 end

--- a/lib/playwright_ex/periphery/serialization.ex
+++ b/lib/playwright_ex/periphery/serialization.ex
@@ -1,15 +1,35 @@
 defmodule PlaywrightEx.Serialization do
   @moduledoc false
 
+  @max_safe_integer 9_007_199_254_740_991
+
   def camelize(:inner_html), do: "innerHTML"
   def camelize(:base_url), do: "baseURL"
+  def camelize(:bypass_csp), do: "bypassCSP"
+  def camelize(:extra_http_headers), do: "extraHTTPHeaders"
+  def camelize(:handle_sighup), do: "handleSIGHUP"
+  def camelize(:handle_sigint), do: "handleSIGINT"
+  def camelize(:handle_sigterm), do: "handleSIGTERM"
   def camelize(:ignore_https_errors), do: "ignoreHTTPSErrors"
+  def camelize(:indexed_db), do: "indexedDB"
   def camelize(:aria_snapshot_json), do: "ariaSnapshotJSON"
+  def camelize(input) when is_binary(input), do: input
   def camelize(input), do: input |> to_string() |> camelize(:lower)
-  def underscore(string), do: string |> Macro.underscore() |> String.to_atom()
 
-  def deep_key_camelize(input), do: deep_key_transform(input, &camelize/1)
-  def deep_key_underscore(input), do: deep_key_transform(input, &underscore/1)
+  def underscore(input) when is_atom(input), do: input
+
+  def underscore(string) when is_binary(string) do
+    underscored = Macro.underscore(string)
+
+    try do
+      String.to_existing_atom(underscored)
+    rescue
+      ArgumentError -> underscored
+    end
+  end
+
+  def deep_key_camelize(input), do: deep_key_transform(input, &camelize/1, :to_wire)
+  def deep_key_underscore(input), do: deep_key_transform(input, &underscore/1, :from_wire)
   def regex_flags_for_protocol(opts), do: do_regex_flags_for_protocol(opts)
 
   @doc """
@@ -22,9 +42,45 @@ defmodule PlaywrightEx.Serialization do
   defp do_serialize_arg(nil), do: %{v: "undefined"}
   defp do_serialize_arg(true), do: %{b: true}
   defp do_serialize_arg(false), do: %{b: false}
+  defp do_serialize_arg(:nan), do: %{v: "NaN"}
+  defp do_serialize_arg(:infinity), do: %{v: "Infinity"}
+  defp do_serialize_arg(:negative_infinity), do: %{v: "-Infinity"}
+  defp do_serialize_arg(:negative_zero), do: %{v: "-0"}
+  defp do_serialize_arg({:handle, index}) when is_integer(index), do: %{h: index}
+  defp do_serialize_arg({:function, name}) when is_binary(name), do: %{fn: name}
+  defp do_serialize_arg({:reference, id}) when is_integer(id), do: %{ref: id}
+  defp do_serialize_arg({:circular_reference, id}) when is_integer(id), do: %{ref: id}
+
+  defp do_serialize_arg(%{type: type, data: data})
+       when type in [
+              :int8,
+              :uint8,
+              :uint8_clamped,
+              :int16,
+              :uint16,
+              :int32,
+              :uint32,
+              :float32,
+              :float64,
+              :bigint64,
+              :biguint64
+            ] and is_binary(data) do
+    %{ta: %{k: typed_array_protocol_kind(type), b: Base.encode64(data)}}
+  end
+
+  defp do_serialize_arg(n) when is_integer(n) and (n > @max_safe_integer or n < -@max_safe_integer),
+    do: %{bi: to_string(n)}
+
   defp do_serialize_arg(n) when is_number(n), do: %{n: n}
   defp do_serialize_arg(s) when is_binary(s), do: %{s: s}
   defp do_serialize_arg(a) when is_atom(a), do: %{s: to_string(a)}
+  defp do_serialize_arg(%DateTime{} = value), do: %{d: DateTime.to_iso8601(value)}
+
+  defp do_serialize_arg(%NaiveDateTime{} = value) do
+    %{d: value |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_iso8601()}
+  end
+
+  defp do_serialize_arg(%URI{} = value), do: %{u: URI.to_string(value)}
   defp do_serialize_arg(%Regex{source: source, opts: opts}), do: %{r: %{p: source, f: do_regex_flags_for_protocol(opts)}}
 
   defp do_serialize_arg(list) when is_list(list) do
@@ -40,67 +96,164 @@ defmodule PlaywrightEx.Serialization do
     }
   end
 
-  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def deserialize_arg(value) do
-    case value do
-      list when is_list(list) ->
-        Enum.map(list, &deserialize_arg/1)
+    ids = collect_serialized_ids(value, %{})
+    deserialize_arg(value, ids, %{})
+  end
 
-      %{a: list} ->
-        Enum.map(list, &deserialize_arg/1)
+  defp deserialize_arg(list, ids, resolving) when is_list(list) do
+    Enum.map(list, &deserialize_arg(&1, ids, resolving))
+  end
 
-      %{b: boolean} ->
-        boolean
+  defp deserialize_arg(%{ref: id}, ids, resolving), do: deserialize_reference(id, ids, resolving)
 
-      %{n: number} ->
-        number
+  defp deserialize_arg(%{a: list} = node, ids, resolving) do
+    resolving = put_resolving_id(resolving, node)
+    Enum.map(list, &deserialize_arg(&1, ids, resolving))
+  end
 
-      %{o: object} ->
-        Map.new(object, fn item -> {item.k, deserialize_arg(item.v)} end)
+  defp deserialize_arg(%{b: boolean}, _ids, _resolving), do: boolean
+  defp deserialize_arg(%{n: number}, _ids, _resolving), do: number
 
-      %{r: %{p: pattern, f: flags}} ->
-        protocol_regex_to_elixir_regex(pattern, flags)
+  defp deserialize_arg(%{o: object} = node, ids, resolving) do
+    resolving = put_resolving_id(resolving, node)
+    Map.new(object, fn item -> {item.k, deserialize_arg(item.v, ids, resolving)} end)
+  end
 
-      %{s: string} ->
-        string
+  defp deserialize_arg(%{r: %{p: pattern, f: flags}}, _ids, _resolving) do
+    protocol_regex_to_elixir_regex(pattern, flags)
+  end
 
-      %{v: "null"} ->
-        nil
+  defp deserialize_arg(%{s: string}, _ids, _resolving), do: string
+  defp deserialize_arg(%{v: "null"}, _ids, _resolving), do: nil
+  defp deserialize_arg(%{v: "undefined"}, _ids, _resolving), do: nil
+  defp deserialize_arg(%{v: "NaN"}, _ids, _resolving), do: :nan
+  defp deserialize_arg(%{v: "Infinity"}, _ids, _resolving), do: :infinity
+  defp deserialize_arg(%{v: "-Infinity"}, _ids, _resolving), do: :negative_infinity
+  defp deserialize_arg(%{v: "-0"}, _ids, _resolving), do: :negative_zero
+  defp deserialize_arg(%{d: datetime}, _ids, _resolving), do: deserialize_datetime(datetime)
+  defp deserialize_arg(%{u: url}, _ids, _resolving), do: URI.parse(url)
+  defp deserialize_arg(%{bi: integer}, _ids, _resolving), do: String.to_integer(integer)
 
-      %{v: "undefined"} ->
-        nil
+  defp deserialize_arg(%{ta: %{b: data, k: kind}}, _ids, _resolving) do
+    %{type: typed_array_kind(kind), data: Base.decode64!(data)}
+  end
 
-      %{ref: _} ->
-        :ref_not_resolved
+  defp deserialize_arg(%{e: error}, _ids, _resolving), do: deserialize_javascript_error(error)
+  defp deserialize_arg(%{h: index}, _ids, _resolving), do: {:handle, index}
+  defp deserialize_arg(%{fn: name}, _ids, _resolving), do: {:function, name}
 
-      other ->
-        raise ArgumentError,
-              "PlaywrightEx.Serialization.deserialize_arg/1: unsupported serialized value shape " <>
-                "(Playwright protocol drift?): #{inspect(other, limit: 20)}"
+  defp deserialize_arg(other, _ids, _resolving) do
+    raise ArgumentError,
+          "PlaywrightEx.Serialization.deserialize_arg/1: unsupported serialized value shape " <>
+            "(Playwright protocol drift?): #{inspect(other, limit: 20)}"
+  end
+
+  defp collect_serialized_ids(list, ids) when is_list(list) do
+    Enum.reduce(list, ids, &collect_serialized_ids/2)
+  end
+
+  defp collect_serialized_ids(%{} = value, ids) do
+    ids = if is_integer(value[:id]), do: Map.put(ids, value.id, value), else: ids
+    Enum.reduce(Map.values(value), ids, &collect_serialized_ids/2)
+  end
+
+  defp collect_serialized_ids(_value, ids), do: ids
+
+  defp deserialize_reference(id, ids, resolving) do
+    cond do
+      Map.has_key?(resolving, id) -> {:circular_reference, id}
+      value = ids[id] -> deserialize_arg(value, ids, Map.put(resolving, id, true))
+      true -> {:reference, id}
     end
   end
 
-  defp deep_key_transform(input, fun) when is_function(fun, 1) do
-    case input do
-      list when is_list(list) ->
-        Enum.map(list, &deep_key_transform(&1, fun))
+  defp put_resolving_id(resolving, %{id: id}) when is_integer(id), do: Map.put(resolving, id, true)
+  defp put_resolving_id(resolving, _value), do: resolving
 
-      map when is_map(map) ->
-        Map.new(map, fn
-          {k, v} when is_map(v) ->
-            {fun.(k), deep_key_transform(v, fun)}
-
-          {k, list} when is_list(list) ->
-            {fun.(k), Enum.map(list, fn v -> deep_key_transform(v, fun) end)}
-
-          {k, v} ->
-            {fun.(k), v}
-        end)
-
-      other ->
-        other
+  defp deserialize_datetime(datetime) do
+    case DateTime.from_iso8601(datetime) do
+      {:ok, value, _offset} -> value
+      {:error, _reason} -> datetime
     end
   end
+
+  defp deserialize_javascript_error(error) do
+    maybe_put(%{name: error.n, message: error.m}, :stack, error[:s])
+  end
+
+  defp typed_array_kind("i8"), do: :int8
+  defp typed_array_kind("ui8"), do: :uint8
+  defp typed_array_kind("ui8c"), do: :uint8_clamped
+  defp typed_array_kind("i16"), do: :int16
+  defp typed_array_kind("ui16"), do: :uint16
+  defp typed_array_kind("i32"), do: :int32
+  defp typed_array_kind("ui32"), do: :uint32
+  defp typed_array_kind("f32"), do: :float32
+  defp typed_array_kind("f64"), do: :float64
+  defp typed_array_kind("bi64"), do: :bigint64
+  defp typed_array_kind("bui64"), do: :biguint64
+
+  defp typed_array_protocol_kind(:int8), do: "i8"
+  defp typed_array_protocol_kind(:uint8), do: "ui8"
+  defp typed_array_protocol_kind(:uint8_clamped), do: "ui8c"
+  defp typed_array_protocol_kind(:int16), do: "i16"
+  defp typed_array_protocol_kind(:uint16), do: "ui16"
+  defp typed_array_protocol_kind(:int32), do: "i32"
+  defp typed_array_protocol_kind(:uint32), do: "ui32"
+  defp typed_array_protocol_kind(:float32), do: "f32"
+  defp typed_array_protocol_kind(:float64), do: "f64"
+  defp typed_array_protocol_kind(:bigint64), do: "bi64"
+  defp typed_array_protocol_kind(:biguint64), do: "bui64"
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  @doc false
+  def serialized_error_message(%{error: %{message: message}}) when is_binary(message), do: message
+
+  def serialized_error_message(%{value: value}) do
+    case deserialize_arg(value) do
+      message when is_binary(message) -> message
+      %{message: message} when is_binary(message) -> message
+      other -> inspect(other)
+    end
+  end
+
+  def serialized_error_message(error), do: inspect(error)
+
+  defp deep_key_transform(list, fun, direction) when is_list(list) do
+    Enum.map(list, &deep_key_transform(&1, fun, direction))
+  end
+
+  defp deep_key_transform(map, fun, direction) when is_map(map) do
+    indexed_db_record? = indexed_db_record?(map)
+    Map.new(map, &transform_key_value(&1, fun, direction, indexed_db_record?))
+  end
+
+  defp deep_key_transform(other, _fun, _direction), do: other
+
+  defp transform_key_value({key, value}, fun, direction, indexed_db_record?) do
+    transformed_key = fun.(key)
+
+    transformed_value =
+      if opaque_json_field?(direction, transformed_key, indexed_db_record?) do
+        value
+      else
+        deep_key_transform(value, fun, direction)
+      end
+
+    {transformed_key, transformed_value}
+  end
+
+  defp indexed_db_record?(map) do
+    Enum.any?([:key_encoded, :value_encoded, "keyEncoded", "valueEncoded"], &Map.has_key?(map, &1))
+  end
+
+  defp opaque_json_field?(:to_wire, key, _indexed_db_record?) when key in ["expressionArg", "firefoxUserPrefs"], do: true
+  defp opaque_json_field?(:from_wire, :snapshot, _indexed_db_record?), do: true
+  defp opaque_json_field?(_direction, key, true) when key in [:key, :value, "key", "value"], do: true
+  defp opaque_json_field?(_direction, _key, _indexed_db_record?), do: false
 
   defp camelize("", :lower), do: ""
   defp camelize(<<?_, t::binary>>, :lower), do: camelize(t, :lower)

--- a/lib/playwright_ex/processes/connection.ex
+++ b/lib/playwright_ex/processes/connection.ex
@@ -12,12 +12,18 @@ defmodule PlaywrightEx.Connection do
   import Kernel, except: [send: 2]
 
   alias PlaywrightEx.FrameEventRecorder
+  alias PlaywrightEx.Serialization
 
   @timeout_grace_factor 1.5
   @min_genserver_timeout to_timeout(second: 1)
 
   defstruct config: %{js_logger: nil, transport: {nil, nil}},
             initializers: %{},
+            types: %{},
+            parents: %{},
+            children: %{},
+            frame_pages: %{},
+            initialization: nil,
             pending_response: %{}
 
   @doc false
@@ -74,7 +80,13 @@ defmodule PlaywrightEx.Connection do
   Get the initializer data for a channel.
   """
   def initializer!(name, guid) do
-    :gen_statem.call(name, {:initializer, guid})
+    case :gen_statem.call(name, {:initializer, guid}) do
+      {:ok, initializer} ->
+        initializer
+
+      :error ->
+        raise ArgumentError, "unknown or disposed Playwright channel #{inspect(guid)}"
+    end
   end
 
   @doc """
@@ -92,15 +104,18 @@ defmodule PlaywrightEx.Connection do
   @impl :gen_statem
   def init(config) do
     %{timeout: timeout, transport: transport} = config
+    initialization_id = System.unique_integer([:positive, :monotonic])
 
     post(transport, %{
+      id: initialization_id,
       guid: "",
       method: :initialize,
       params: %{sdk_language: :javascript},
       metadata: %{timeout: timeout}
     })
 
-    {:ok, :pending, %__MODULE__{config: config}}
+    initialization = %{id: initialization_id, acknowledged?: false, playwright_created?: false}
+    {:ok, :pending, %__MODULE__{config: config, initialization: initialization}}
   end
 
   defp post({transport_module, transport_name}, msg) do
@@ -109,7 +124,23 @@ defmodule PlaywrightEx.Connection do
 
   @doc false
   def pending(:cast, {:playwright_msg, %{method: :__create__, params: %{guid: "Playwright"}} = msg}, data) do
-    {:next_state, :started, handle_create(data, msg)}
+    data =
+      data
+      |> handle_protocol_message(msg)
+      |> put_in([Access.key!(:initialization), Access.key!(:playwright_created?)], true)
+
+    maybe_finish_initialization(data)
+  end
+
+  def pending(:cast, {:playwright_msg, %{id: id} = msg}, %{initialization: %{id: id}} = data) do
+    case msg do
+      %{error: error} ->
+        {:stop, {:playwright_initialization_failed, error}, data}
+
+      _response ->
+        data = put_in(data.initialization.acknowledged?, true)
+        maybe_finish_initialization(data)
+    end
   end
 
   def pending(:cast, _msg, _data), do: {:keep_state_and_data, [:postpone]}
@@ -122,7 +153,7 @@ defmodule PlaywrightEx.Connection do
   end
 
   def started({:call, from}, {:initializer, guid}, data) do
-    {:keep_state_and_data, [{:reply, from, Map.fetch!(data.initializers, guid)}]}
+    {:keep_state_and_data, [{:reply, from, Map.fetch(data.initializers, guid)}]}
   end
 
   def started({:call, from}, :remote?, data) do
@@ -131,36 +162,11 @@ defmodule PlaywrightEx.Connection do
   end
 
   def started(:cast, {:subscribe, recipient, guid}, data) do
-    group = pg_group(guid)
-
-    if recipient in :pg.get_members(data.config.pg_scope, group) do
-      :ok
-    else
-      :ok = :pg.join(data.config.pg_scope, group, recipient)
-    end
-
-    :keep_state_and_data
+    {:keep_state, subscribe_recipient(data, recipient, guid)}
   end
 
   def started(:cast, {:unsubscribe, recipient, guid}, data) do
     _ = :pg.leave(data.config.pg_scope, pg_group(guid), recipient)
-    :keep_state_and_data
-  end
-
-  def started(:cast, {:playwright_msg, %{method: :page_error} = msg}, data) do
-    if module = data.config.js_logger do
-      module.log(:error, msg.params.error, msg)
-    end
-
-    :keep_state_and_data
-  end
-
-  def started(:cast, {:playwright_msg, %{method: :console} = msg}, data) do
-    if module = data.config.js_logger do
-      level = log_level_from_js(msg[:params][:type])
-      module.log(level, msg.params.text, msg)
-    end
-
     :keep_state_and_data
   end
 
@@ -172,22 +178,35 @@ defmodule PlaywrightEx.Connection do
   end
 
   def started(:cast, {:playwright_msg, msg}, data) do
-    {:keep_state,
-     data |> handle_create(msg) |> maybe_start_frame_event_recorder(msg) |> notify_subscribers(msg) |> handle_dispose(msg)}
+    maybe_log_protocol_message(data, msg)
+    {:keep_state, handle_protocol_message(data, msg)}
   end
 
   defp handle_create(data, %{method: :__create__} = msg) do
-    put_in(data.initializers[msg.params.guid], msg.params.initializer)
+    child_guid = msg.params.guid
+
+    data
+    |> put_in([Access.key!(:initializers), child_guid], msg.params.initializer)
+    |> put_in([Access.key!(:types), child_guid], msg.params[:type])
+    |> put_parent(child_guid, msg[:guid])
   end
 
   defp handle_create(data, _msg), do: data
+
+  defp handle_adopt(data, %{method: :__adopt__, guid: parent_guid, params: %{guid: child_guid}}) do
+    put_parent(data, child_guid, parent_guid)
+  end
+
+  defp handle_adopt(data, _msg), do: data
 
   defp maybe_start_frame_event_recorder(data, %{
          method: :__create__,
          params: %{guid: guid, initializer: %{url: _url, load_states: _load_states} = initializer}
        }) do
-    _ = FrameEventRecorder.ensure_started(data.config.name, guid, initializer)
-    data
+    case FrameEventRecorder.ensure_started(data.config.name, guid, initializer) do
+      {:ok, pid} -> subscribe_recipient(data, pid, guid)
+      {:error, _reason} -> data
+    end
   end
 
   defp maybe_start_frame_event_recorder(data, %{method: :__create__}) do
@@ -196,20 +215,50 @@ defmodule PlaywrightEx.Connection do
 
   defp maybe_start_frame_event_recorder(data, _msg), do: data
 
+  defp maybe_associate_frame_with_page(data, %{method: :__create__, params: %{guid: guid, type: "Page"} = params}) do
+    case params.initializer do
+      %{main_frame: %{guid: frame_guid}} -> associate_frame_with_page(data, frame_guid, guid)
+      _initializer -> data
+    end
+  end
+
+  defp maybe_associate_frame_with_page(data, %{method: :__create__, params: %{guid: guid, type: "Frame"}}) do
+    associate_created_frame(data, guid)
+  end
+
+  defp maybe_associate_frame_with_page(data, %{method: :__create__, params: %{guid: guid}}) do
+    case data.initializers[guid] do
+      %{main_frame: %{guid: frame_guid}} ->
+        associate_frame_with_page(data, frame_guid, guid)
+
+      %{url: _url, load_states: _load_states} ->
+        associate_created_frame(data, guid)
+
+      _initializer ->
+        data
+    end
+  end
+
+  defp maybe_associate_frame_with_page(data, %{method: :__adopt__, guid: parent_guid, params: %{guid: child_guid}}) do
+    associate_frame_from_parent(data, child_guid, parent_guid)
+  end
+
+  defp maybe_associate_frame_with_page(data, _msg), do: data
+
   defp handle_dispose(data, %{method: :__dispose__} = msg) do
-    data
-    |> Map.update!(:initializers, &Map.delete(&1, msg.guid))
-    |> stop_disposed_frame_event_recorder(msg.guid)
-    |> clear_disposed_guid_subscribers(msg.guid)
+    disposed_guids = collect_descendants(data.children, msg.guid)
+
+    Enum.each(tl(disposed_guids), fn guid ->
+      notify_guid_subscribers(data, guid, %{guid: guid, method: :__dispose__, params: %{}})
+    end)
+
+    Enum.reduce(disposed_guids, data, &dispose_guid(&2, &1))
   end
 
   defp handle_dispose(data, _msg), do: data
 
   defp notify_subscribers(data, %{guid: guid} = msg) do
-    for pid <- :pg.get_members(data.config.pg_scope, pg_group(guid)) do
-      Kernel.send(pid, {:playwright_msg, msg})
-    end
-
+    notify_guid_subscribers(data, guid, msg)
     data
   end
 
@@ -231,6 +280,154 @@ defmodule PlaywrightEx.Connection do
     _ = FrameEventRecorder.terminate_frame(data.config.name, guid)
     data
   end
+
+  defp maybe_finish_initialization(%{initialization: %{acknowledged?: true, playwright_created?: true}} = data) do
+    {:next_state, :started, %{data | initialization: nil}}
+  end
+
+  defp maybe_finish_initialization(data), do: {:keep_state, data}
+
+  defp handle_protocol_message(data, msg) do
+    data
+    |> handle_create(msg)
+    |> handle_adopt(msg)
+    |> maybe_start_frame_event_recorder(msg)
+    |> maybe_associate_frame_with_page(msg)
+    |> notify_subscribers(msg)
+    |> handle_dispose(msg)
+  end
+
+  defp put_parent(data, _child_guid, nil), do: data
+
+  defp put_parent(data, child_guid, parent_guid) do
+    old_parent = data.parents[child_guid]
+
+    children =
+      data.children
+      |> remove_child(old_parent, child_guid)
+      |> Map.update(parent_guid, MapSet.new([child_guid]), &MapSet.put(&1, child_guid))
+
+    %{data | parents: Map.put(data.parents, child_guid, parent_guid), children: children}
+  end
+
+  defp remove_child(children, nil, _child_guid), do: children
+
+  defp remove_child(children, parent_guid, child_guid) do
+    case Map.get(children, parent_guid) do
+      nil ->
+        children
+
+      siblings ->
+        siblings = MapSet.delete(siblings, child_guid)
+
+        if MapSet.size(siblings) == 0,
+          do: Map.delete(children, parent_guid),
+          else: Map.put(children, parent_guid, siblings)
+    end
+  end
+
+  defp associate_created_frame(data, frame_guid) do
+    case data.frame_pages[frame_guid] do
+      nil -> associate_frame_from_parent(data, frame_guid, data.parents[frame_guid])
+      page_guid -> associate_frame_with_page(data, frame_guid, page_guid)
+    end
+  end
+
+  defp associate_frame_from_parent(data, _frame_guid, nil), do: data
+
+  defp associate_frame_from_parent(data, frame_guid, parent_guid) do
+    cond do
+      data.types[parent_guid] == "Page" -> associate_frame_with_page(data, frame_guid, parent_guid)
+      page_guid = data.frame_pages[parent_guid] -> associate_frame_with_page(data, frame_guid, page_guid)
+      true -> data
+    end
+  end
+
+  defp associate_frame_with_page(data, frame_guid, page_guid) do
+    old_page_guid = data.frame_pages[frame_guid]
+
+    data =
+      case FrameEventRecorder.attach_page(data.config.name, frame_guid, page_guid) do
+        {:ok, pid} ->
+          maybe_unsubscribe_recipient(data, pid, old_page_guid, page_guid)
+          subscribe_recipient(data, pid, page_guid)
+
+        :not_found ->
+          data
+      end
+
+    data = put_in(data.frame_pages[frame_guid], page_guid)
+
+    data.children
+    |> Map.get(frame_guid, MapSet.new())
+    |> Enum.filter(&(data.types[&1] == "Frame"))
+    |> Enum.reduce(data, &associate_frame_with_page(&2, &1, page_guid))
+  end
+
+  defp collect_descendants(children, guid), do: collect_descendants(children, guid, %{})
+
+  defp collect_descendants(children, guid, seen) do
+    if Map.has_key?(seen, guid) do
+      []
+    else
+      seen = Map.put(seen, guid, true)
+
+      descendants =
+        children
+        |> Map.get(guid, MapSet.new())
+        |> Enum.flat_map(&collect_descendants(children, &1, seen))
+
+      [guid | descendants]
+    end
+  end
+
+  defp dispose_guid(data, guid) do
+    parent_guid = data.parents[guid]
+
+    data
+    |> Map.update!(:initializers, &Map.delete(&1, guid))
+    |> Map.update!(:types, &Map.delete(&1, guid))
+    |> Map.update!(:parents, &Map.delete(&1, guid))
+    |> Map.update!(:children, &(&1 |> remove_child(parent_guid, guid) |> Map.delete(guid)))
+    |> Map.update!(:frame_pages, &Map.delete(&1, guid))
+    |> stop_disposed_frame_event_recorder(guid)
+    |> clear_disposed_guid_subscribers(guid)
+  end
+
+  defp notify_guid_subscribers(data, guid, msg) do
+    for pid <- :pg.get_members(data.config.pg_scope, pg_group(guid)) do
+      Kernel.send(pid, {:playwright_msg, msg})
+    end
+  end
+
+  defp subscribe_recipient(data, recipient, guid) do
+    group = pg_group(guid)
+
+    if recipient not in :pg.get_members(data.config.pg_scope, group) do
+      :ok = :pg.join(data.config.pg_scope, group, recipient)
+    end
+
+    data
+  end
+
+  defp maybe_unsubscribe_recipient(_data, _recipient, nil, _new_guid), do: :ok
+  defp maybe_unsubscribe_recipient(_data, _recipient, guid, guid), do: :ok
+
+  defp maybe_unsubscribe_recipient(data, recipient, old_guid, _new_guid) do
+    _ = :pg.leave(data.config.pg_scope, pg_group(old_guid), recipient)
+    :ok
+  end
+
+  defp maybe_log_protocol_message(%{config: %{js_logger: module}}, %{method: :page_error} = msg)
+       when not is_nil(module) do
+    module.log(:error, Serialization.serialized_error_message(msg.params.error), msg)
+  end
+
+  defp maybe_log_protocol_message(%{config: %{js_logger: module}}, %{method: :console} = msg) when not is_nil(module) do
+    module.log(log_level_from_js(msg.params[:type]), msg.params[:text], msg)
+  end
+
+  defp maybe_log_protocol_message(_data, _msg), do: :ok
 
   defp log_level_from_js("error"), do: :error
   defp log_level_from_js("debug"), do: :debug

--- a/lib/playwright_ex/processes/frame_event_recorder.ex
+++ b/lib/playwright_ex/processes/frame_event_recorder.ex
@@ -48,6 +48,18 @@ defmodule PlaywrightEx.FrameEventRecorder do
     end
   end
 
+  @spec attach_page(atom(), PlaywrightEx.guid(), PlaywrightEx.guid()) :: {:ok, pid()} | :not_found
+  def attach_page(connection, frame_id, page_id) do
+    case lookup(connection, frame_id) do
+      {:ok, pid} ->
+        GenServer.cast(pid, {:attach_page, page_id})
+        {:ok, pid}
+
+      :not_found ->
+        :not_found
+    end
+  end
+
   @spec registry_name(atom()) :: atom()
   def registry_name(connection), do: Module.concat(connection, "FrameEventRecorderRegistry")
 
@@ -70,20 +82,29 @@ defmodule PlaywrightEx.FrameEventRecorder do
   @impl true
   def init(%{connection: connection, frame_id: frame_id} = opts) do
     frame_initializer = Map.get(opts, :initializer) || Connection.initializer!(connection, frame_id)
-    page_id = extract_page_id(frame_initializer)
 
     Connection.subscribe(connection, self(), frame_id)
-    maybe_subscribe_page(connection, page_id)
 
     state = %__MODULE__{
       connection: connection,
       frame_id: frame_id,
-      page_id: page_id,
       url: frame_initializer[:url] || "",
       load_states: FrameWaiter.normalize_load_states(frame_initializer[:load_states])
     }
 
     {:ok, state}
+  end
+
+  @impl true
+  def handle_cast({:attach_page, page_id}, %{page_id: page_id} = state), do: {:noreply, state}
+
+  def handle_cast({:attach_page, page_id}, state) do
+    {:noreply, %{state | page_id: page_id}}
+  end
+
+  def handle_cast(:dispose, state) do
+    state = fail_waiters(state, fn _waiter -> true end, {:error, %{message: @frame_detached_error}})
+    {:stop, {:shutdown, :frame_detached}, state}
   end
 
   @impl true
@@ -168,7 +189,7 @@ defmodule PlaywrightEx.FrameEventRecorder do
   @spec terminate_frame(atom(), PlaywrightEx.guid()) :: :ok
   def terminate_frame(connection, frame_id) do
     case lookup(connection, frame_id) do
-      {:ok, pid} -> Process.exit(pid, :normal)
+      {:ok, pid} -> GenServer.cast(pid, :dispose)
       :not_found -> :ok
     end
 
@@ -278,16 +299,6 @@ defmodule PlaywrightEx.FrameEventRecorder do
 
   defp maybe_put_initializer(opts, initializer) when is_map(initializer), do: Map.put(opts, :initializer, initializer)
   defp maybe_put_initializer(opts, _initializer), do: opts
-
-  defp extract_page_id(%{page: %{guid: guid}}) when is_binary(guid), do: guid
-  defp extract_page_id(%{page: guid}) when is_binary(guid), do: guid
-  defp extract_page_id(_initializer), do: nil
-
-  defp maybe_subscribe_page(_connection, nil), do: :ok
-
-  defp maybe_subscribe_page(connection, page_id) do
-    Connection.subscribe(connection, self(), page_id)
-  end
 
   defp url_waiter?({:url, _url_matcher, _wait_state, _phase}), do: true
   defp url_waiter?(_waiter), do: false

--- a/lib/playwright_ex/processes/port_transport.ex
+++ b/lib/playwright_ex/processes/port_transport.ex
@@ -21,7 +21,6 @@ defmodule PlaywrightEx.PortTransport do
   alias PlaywrightEx.Serialization
 
   defstruct port: nil,
-            remaining: 0,
             buffer: "",
             connection_name: Connection
 
@@ -45,7 +44,7 @@ defmodule PlaywrightEx.PortTransport do
   @impl GenServer
   def init(%{executable: executable, env: env} = opts) do
     env = Enum.map(env, fn {k, v} -> {String.to_charlist(k), String.to_charlist(v)} end)
-    port = Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, args: ["run-driver"], env: env])
+    port = Port.open({:spawn_executable, executable}, [:binary, args: ["run-driver"], env: env])
     connection_name = Map.get(opts, :connection_name, Connection)
     {:ok, %__MODULE__{port: port, connection_name: connection_name}}
   end
@@ -62,36 +61,24 @@ defmodule PlaywrightEx.PortTransport do
 
   @impl GenServer
   def handle_info({port, {:data, data}}, %{port: port} = state) do
-    {remaining, buffer, frames} = parse(data, state.remaining, state.buffer, [])
+    {buffer, frames} = parse_frames(state.buffer <> data, [])
 
     for frame <- frames do
       Connection.handle_playwright_msg(state.connection_name, from_json(frame))
     end
 
-    {:noreply, %{state | buffer: buffer, remaining: remaining}}
+    {:noreply, %{state | buffer: buffer}}
   end
 
-  defp parse(data, remaining, buffer, frames)
+  defp parse_frames(buffer, frames) when byte_size(buffer) < 4, do: {buffer, Enum.reverse(frames)}
 
-  defp parse(<<head::unsigned-little-integer-size(32)>>, 0, "", frames) do
-    {head, "", frames}
-  end
-
-  defp parse(<<head::unsigned-little-integer-size(32), data::binary>>, 0, "", frames) do
-    parse(data, head, "", frames)
-  end
-
-  defp parse(<<data::binary>>, remaining, buffer, frames) when byte_size(data) == remaining do
-    {0, "", frames ++ [buffer <> data]}
-  end
-
-  defp parse(<<data::binary>>, remaining, buffer, frames) when byte_size(data) > remaining do
-    <<frame::size(^remaining)-binary, tail::binary>> = data
-    parse(tail, 0, "", frames ++ [buffer <> frame])
-  end
-
-  defp parse(<<data::binary>>, remaining, buffer, frames) when byte_size(data) < remaining do
-    {remaining - byte_size(data), buffer <> data, frames}
+  defp parse_frames(<<length::unsigned-little-integer-size(32), payload::binary>> = buffer, frames) do
+    if byte_size(payload) < length do
+      {buffer, Enum.reverse(frames)}
+    else
+      <<frame::binary-size(^length), tail::binary>> = payload
+      parse_frames(tail, [frame | frames])
+    end
   end
 
   defp to_json(msg) do

--- a/lib/playwright_ex/processes/websocket_transport.ex
+++ b/lib/playwright_ex/processes/websocket_transport.ex
@@ -57,7 +57,12 @@ if Code.ensure_loaded?(WebSockex) do
     defp connect_with_retry(ws_endpoint, name, connection_name, retries) do
       state = %__MODULE__{ws_endpoint: ws_endpoint, connection_name: connection_name}
 
-      case WebSockex.start_link(ws_endpoint, __MODULE__, state, name: name) do
+      user_agent = "Playwright/#{PlaywrightEx.minimum_supported_version()}"
+
+      case WebSockex.start_link(ws_endpoint, __MODULE__, state,
+             name: name,
+             extra_headers: [{"User-Agent", user_agent}]
+           ) do
         {:ok, pid} ->
           {:ok, pid}
 
@@ -93,7 +98,7 @@ if Code.ensure_loaded?(WebSockex) do
     def handle_frame({:binary, _data}, state), do: {:ok, state}
 
     @impl WebSockex
-    def handle_disconnect(_status, state), do: {:reconnect, state}
+    def handle_disconnect(_status, state), do: {:ok, state}
 
     @impl WebSockex
     def terminate(_reason, _state), do: :ok

--- a/lib/playwright_ex/supervisor.ex
+++ b/lib/playwright_ex/supervisor.ex
@@ -107,7 +107,9 @@ defmodule PlaywrightEx.Supervisor do
 
     transport_name = Module.concat(name, "PortTransport")
 
-    child_spec = {PortTransport, executable: executable, name: transport_name, connection_name: connection_name, env: env}
+    child_spec =
+      {PortTransport, executable: executable, name: transport_name, connection_name: connection_name, env: env}
+
     {child_spec, {PortTransport, transport_name}}
   end
 

--- a/test/playwright_ex/browser_context_test.exs
+++ b/test/playwright_ex/browser_context_test.exs
@@ -95,7 +95,7 @@ defmodule PlaywrightEx.BrowserContextTest do
 
       assert {:ok, %{cookies: [], credentials: [], origins: [stored_origin]}} =
                BrowserContext.storage_state(browser_context.guid,
-                 indexedDB: true,
+                 indexed_db: true,
                  opfs: true,
                  credentials: true,
                  timeout: @timeout
@@ -124,6 +124,44 @@ defmodule PlaywrightEx.BrowserContextTest do
       assert {:ok, %{credentials: [^credential]}} =
                BrowserContext.storage_state(browser_context.guid,
                  credentials: true,
+                 timeout: @timeout
+               )
+    end
+
+    test "restores the Playwright 1.63 credentials field", %{browser_context: browser_context} do
+      assert {:ok, _} =
+               BrowserContext.set_storage_state(browser_context.guid,
+                 cookies: [],
+                 origins: [],
+                 credentials: [],
+                 timeout: @timeout
+               )
+    end
+  end
+
+  describe "cookies" do
+    test "normalizes SameSite and regex clear filters", %{browser_context: browser_context} do
+      assert {:ok, _} =
+               BrowserContext.add_cookies(browser_context.guid,
+                 cookies: [%{name: "session", value: "1", url: "https://example.com", same_site: :lax}],
+                 timeout: @timeout
+               )
+
+      assert {:ok, [%{name: "session", same_site: "Lax"}]} =
+               BrowserContext.cookies(browser_context.guid,
+                 urls: ["https://example.com"],
+                 timeout: @timeout
+               )
+
+      assert {:ok, _} =
+               BrowserContext.clear_cookies(browser_context.guid,
+                 name: ~r/^sess/i,
+                 timeout: @timeout
+               )
+
+      assert {:ok, []} =
+               BrowserContext.cookies(browser_context.guid,
+                 urls: ["https://example.com"],
                  timeout: @timeout
                )
     end

--- a/test/playwright_ex/browser_test.exs
+++ b/test/playwright_ex/browser_test.exs
@@ -34,5 +34,28 @@ defmodule PlaywrightEx.BrowserTest do
                  timeout: @timeout
                )
     end
+
+    test "normalizes Playwright 1.63 context enums, headers, and acronym casing", %{browser: browser} do
+      assert {:ok, _} =
+               Browser.new_context(browser.guid,
+                 accept_downloads: false,
+                 bypass_csp: true,
+                 color_scheme: :no_preference,
+                 extra_http_headers: %{"x-playwright-ex" => "1"},
+                 timeout: @timeout
+               )
+
+      assert {:ok, _} =
+               Browser.new_context(browser.guid,
+                 color_scheme: :null,
+                 timeout: @timeout
+               )
+
+      assert {:ok, _} =
+               Browser.new_context(browser.guid,
+                 color_scheme: :no_override,
+                 timeout: @timeout
+               )
+    end
   end
 end

--- a/test/playwright_ex/element_handle_test.exs
+++ b/test/playwright_ex/element_handle_test.exs
@@ -24,7 +24,7 @@ defmodule PlaywrightEx.ElementHandleTest do
 
     assert {:ok, _} =
              Page.update_subscription(page.guid,
-               event: :fileChooser,
+               event: :file_chooser,
                enabled: true,
                timeout: @timeout
              )

--- a/test/playwright_ex/frame_test.exs
+++ b/test/playwright_ex/frame_test.exs
@@ -367,6 +367,76 @@ defmodule PlaywrightEx.FrameTest do
                  timeout: @timeout
                )
     end
+
+    test "maps a numeric polling option to pollingInterval", %{frame: frame} do
+      set_html(frame.guid, "")
+
+      eval(frame.guid, """
+      () => {
+        window.__polled = false;
+        setTimeout(() => { window.__polled = true; }, 50);
+      }
+      """)
+
+      assert {:ok, %{handle: %{guid: _}}} =
+               Frame.wait_for_function(frame.guid,
+                 expression: "() => window.__polled",
+                 is_function: true,
+                 polling: 20,
+                 timeout: @timeout
+               )
+    end
+  end
+
+  describe "select_option/2" do
+    setup %{frame: frame} do
+      set_html(
+        frame.guid,
+        """
+        <select id="choice" multiple>
+          <option id="alpha" value="a">Alpha</option>
+          <option id="beta" value="b">Beta</option>
+          <option id="gamma" value="c">Gamma</option>
+        </select>
+        """
+      )
+
+      :ok
+    end
+
+    test "normalizes scalar strings and returns selected values", %{frame: frame} do
+      assert {:ok, ["a"]} =
+               Frame.select_option(frame.guid, selector: "#choice", options: "a", timeout: @timeout)
+    end
+
+    test "normalizes option maps and element handles", %{frame: frame} do
+      assert {:ok, ["b"]} =
+               Frame.select_option(frame.guid,
+                 selector: "#choice",
+                 options: %{label: "Beta"},
+                 timeout: @timeout
+               )
+
+      assert {:ok, element} = Frame.wait_for_selector(frame.guid, selector: "#alpha", timeout: @timeout)
+
+      assert {:ok, ["a"]} =
+               Frame.select_option(frame.guid,
+                 selector: "#choice",
+                 options: element,
+                 timeout: @timeout
+               )
+    end
+
+    test "accepts element handles, strings, and descriptors together", %{frame: frame} do
+      assert {:ok, element} = Frame.wait_for_selector(frame.guid, selector: "#alpha", timeout: @timeout)
+
+      assert {:ok, ["a", "b", "c"]} =
+               Frame.select_option(frame.guid,
+                 selector: "#choice",
+                 options: [element, "b", %{label: "Gamma"}],
+                 timeout: @timeout
+               )
+    end
   end
 
   describe "wait_for_load_state/2" do

--- a/test/playwright_ex/periphery/channel_response_test.exs
+++ b/test/playwright_ex/periphery/channel_response_test.exs
@@ -1,0 +1,28 @@
+defmodule PlaywrightEx.ChannelResponseTest do
+  use ExUnit.Case, async: true
+
+  alias PlaywrightEx.ChannelResponse
+
+  test "unwraps an omitted void result as an empty result object" do
+    assert {:ok, :ok} = ChannelResponse.unwrap(%{id: 1}, fn %{} -> :ok end)
+  end
+
+  test "preserves protocol call logs on errors" do
+    response = %{id: 1, error: %{message: "boom"}, log: ["waiting for selector"]}
+
+    assert {:error, %{message: "boom", log: ["waiting for selector"]}} =
+             ChannelResponse.unwrap(response, & &1)
+  end
+
+  test "preserves error details and call logs together" do
+    response = %{
+      id: 1,
+      error: %{message: "boom"},
+      error_details: %{timed_out: true},
+      log: ["waiting"]
+    }
+
+    assert {:error, {%{message: "boom", log: ["waiting"]}, %{timed_out: true}}} =
+             ChannelResponse.unwrap(response, & &1)
+  end
+end

--- a/test/playwright_ex/periphery/serialization_test.exs
+++ b/test/playwright_ex/periphery/serialization_test.exs
@@ -93,6 +93,95 @@ defmodule PlaywrightEx.SerializationTest do
                  Serialization.regex_flags_for_protocol(value.opts)
       end
     end
+
+    test "round-trips Playwright 1.63 date, URL, and bigint values" do
+      datetime = ~U[2026-09-08 12:34:56Z]
+
+      for value <- [datetime, URI.parse("https://example.com/a?b=c"), 9_007_199_254_740_992] do
+        serialized = Serialization.serialize_arg(value)
+        assert Serialization.deserialize_arg(serialized.value) == value
+      end
+    end
+
+    test "deserializes special numeric and typed-array values" do
+      assert :nan = Serialization.deserialize_arg(%{v: "NaN"})
+      assert :infinity = Serialization.deserialize_arg(%{v: "Infinity"})
+      assert :negative_infinity = Serialization.deserialize_arg(%{v: "-Infinity"})
+      assert :negative_zero = Serialization.deserialize_arg(%{v: "-0"})
+
+      assert %{type: :uint8, data: <<0, 1, 255>>} =
+               Serialization.deserialize_arg(%{ta: %{k: "ui8", b: Base.encode64(<<0, 1, 255>>)}})
+
+      for value <- [:nan, :infinity, :negative_infinity, :negative_zero, %{type: :uint8, data: <<0, 1, 255>>}] do
+        serialized = Serialization.serialize_arg(value)
+        assert Serialization.deserialize_arg(serialized.value) == value
+      end
+    end
+
+    test "deserializes JavaScript errors, handles, and functions" do
+      assert %{name: "TypeError", message: "bad", stack: "stack"} =
+               Serialization.deserialize_arg(%{e: %{n: "TypeError", m: "bad", s: "stack"}})
+
+      assert {:handle, 2} = Serialization.deserialize_arg(%{h: 2})
+      assert {:function, "fn@1"} = Serialization.deserialize_arg(%{fn: "fn@1"})
+
+      for value <- [{:handle, 2}, {:function, "fn@1"}] do
+        serialized = Serialization.serialize_arg(value)
+        assert Serialization.deserialize_arg(serialized.value) == value
+      end
+    end
+
+    test "resolves non-cyclic references and reports cyclic references" do
+      assert ["value", "value"] =
+               Serialization.deserialize_arg(%{a: [%{s: "value", id: 1}, %{ref: 1}]})
+
+      assert [{:circular_reference, 1}] =
+               Serialization.deserialize_arg(%{a: [%{ref: 1}], id: 1})
+    end
+  end
+
+  describe "wire key conversion" do
+    test "preserves arbitrary JSON keys and does not intern unknown protocol keys" do
+      unknown = "unknown_#{System.unique_integer([:positive])}"
+      nested_unknown = "nested_#{System.unique_integer([:positive])}"
+
+      assert %{^unknown => %{^nested_unknown => true}} =
+               Serialization.deep_key_underscore(%{unknown => %{nested_unknown => true}})
+
+      refute is_atom(hd(Map.keys(Serialization.deep_key_underscore(%{unknown => true}))))
+
+      assert %{"alreadyCamel" => %{"snake_key" => true}} =
+               Serialization.deep_key_camelize(%{"alreadyCamel" => %{"snake_key" => true}})
+    end
+
+    test "preserves expression arguments and structured snapshots as opaque JSON" do
+      assert %{"expressionArg" => %{:snake_key => %{"nested_key" => true}}} =
+               Serialization.deep_key_camelize(%{expression_arg: %{snake_key: %{"nested_key" => true}}})
+
+      assert %{snapshot: %{"role_key" => %{"nested_key" => true}}} =
+               Serialization.deep_key_underscore(%{"snapshot" => %{"role_key" => %{"nested_key" => true}}})
+    end
+
+    test "preserves IndexedDB key and value payloads" do
+      payload = %{
+        "keyEncoded" => "encoded-key",
+        "valueEncoded" => "encoded-value",
+        "key" => %{"user_key" => 1},
+        "value" => %{"user_value" => 2}
+      }
+
+      assert %{
+               key_encoded: "encoded-key",
+               value_encoded: "encoded-value",
+               key: %{"user_key" => 1},
+               value: %{"user_value" => 2}
+             } = Serialization.deep_key_underscore(payload)
+    end
+  end
+
+  test "extracts messages from serialized errors" do
+    assert "boom" = Serialization.serialized_error_message(%{error: %{message: "boom"}})
+    assert "boom" = Serialization.serialized_error_message(%{value: %{s: "boom"}})
   end
 
   describe "regex_flags_for_protocol/1" do

--- a/test/playwright_ex/processes/connection_test.exs
+++ b/test/playwright_ex/processes/connection_test.exs
@@ -16,11 +16,43 @@ defmodule PlaywrightEx.ConnectionTest do
     def post(_name, _msg), do: :ok
   end
 
+  defmodule TestJsLogger do
+    @moduledoc false
+
+    def log(level, message, msg) do
+      send(msg.params.test_pid, {:js_log, level, message})
+    end
+  end
+
+  test "waits for both the initialize response and Playwright creation" do
+    name = start_uninitialized_connection!(self())
+    assert_receive {:transport_post, %{id: initialization_id, method: :initialize}}
+
+    Connection.handle_playwright_msg(name, %{
+      guid: "",
+      method: :__create__,
+      params: %{type: "Playwright", guid: "Playwright", initializer: %{}}
+    })
+
+    assert {:pending, _} = :sys.get_state(name)
+    Connection.handle_playwright_msg(name, %{id: initialization_id, result: %{playwright: %{guid: "Playwright"}}})
+
+    assert_eventually(fn -> match?({:started, _}, :sys.get_state(name)) end)
+  end
+
   test "sends command timeouts in metadata" do
     name = start_connection!(self())
 
     assert_receive {:transport_post,
-                    %{method: :initialize, params: %{sdk_language: :javascript}, metadata: %{timeout: 1_000}}}
+                    %{
+                      id: initialization_id,
+                      guid: "",
+                      method: :initialize,
+                      params: %{sdk_language: :javascript},
+                      metadata: %{timeout: 1_000}
+                    }}
+
+    assert is_integer(initialization_id)
 
     task =
       Task.async(fn ->
@@ -93,7 +125,79 @@ defmodule PlaywrightEx.ConnectionTest do
     refute_receive {:playwright_msg, %{guid: "guid-4"}}
   end
 
-  defp start_connection!(transport_name \\ :dummy) do
+  test "adoption and recursive disposal remove child channels" do
+    name = start_connection!()
+
+    Connection.handle_playwright_msg(name, %{
+      guid: "Playwright",
+      method: :__create__,
+      params: %{type: "BrowserContext", guid: "context-1", initializer: %{}}
+    })
+
+    Connection.handle_playwright_msg(name, %{
+      guid: "context-1",
+      method: :__create__,
+      params: %{type: "Frame", guid: "frame-1", initializer: %{url: "about:blank", load_states: []}}
+    })
+
+    Connection.handle_playwright_msg(name, %{
+      guid: "context-1",
+      method: :__create__,
+      params: %{type: "Page", guid: "page-1", initializer: %{main_frame: %{guid: "frame-1"}}}
+    })
+
+    Connection.handle_playwright_msg(name, %{guid: "page-1", method: :__adopt__, params: %{guid: "frame-1"}})
+    Connection.subscribe(name, self(), "page-1")
+    Connection.subscribe(name, self(), "frame-1")
+    Connection.handle_playwright_msg(name, %{guid: "page-1", method: :__dispose__, params: %{}})
+
+    assert_receive {:playwright_msg, %{guid: "page-1", method: :__dispose__}}
+    assert_receive {:playwright_msg, %{guid: "frame-1", method: :__dispose__}}
+    assert_raise ArgumentError, ~r/unknown or disposed/, fn -> Connection.initializer!(name, "frame-1") end
+    assert Process.alive?(Process.whereis(name))
+  end
+
+  test "console and page errors are logged and still delivered to subscribers" do
+    name = start_connection!(:dummy, TestJsLogger)
+    Connection.subscribe(name, self(), "context-1")
+
+    console = %{
+      guid: "context-1",
+      method: :console,
+      params: %{type: "error", text: "console boom", test_pid: self()}
+    }
+
+    Connection.handle_playwright_msg(name, console)
+    assert_receive {:js_log, :error, "console boom"}
+    assert_receive {:playwright_msg, ^console}
+
+    page_error = %{
+      guid: "context-1",
+      method: :page_error,
+      params: %{error: %{error: %{name: "Error", message: "page boom"}}, test_pid: self()}
+    }
+
+    Connection.handle_playwright_msg(name, page_error)
+    assert_receive {:js_log, :error, "page boom"}
+    assert_receive {:playwright_msg, ^page_error}
+  end
+
+  defp start_connection!(transport_name \\ :dummy, js_logger \\ nil) do
+    name = start_uninitialized_connection!(transport_name, js_logger)
+    {:pending, data} = :sys.get_state(name)
+    Connection.handle_playwright_msg(name, %{id: data.initialization.id, result: %{}})
+
+    Connection.handle_playwright_msg(name, %{
+      guid: "",
+      method: :__create__,
+      params: %{type: "Playwright", guid: "Playwright", initializer: %{}}
+    })
+
+    assert_eventually(fn -> match?({:started, _}, :sys.get_state(name)) end)
+    name
+  end
+
+  defp start_uninitialized_connection!(transport_name, js_logger \\ nil) do
     name = String.to_atom("connection_test_#{System.unique_integer([:positive])}")
     scope = String.to_atom("connection_test_scope_#{System.unique_integer([:positive])}")
     {:ok, _} = :pg.start_link(scope)
@@ -103,15 +207,9 @@ defmodule PlaywrightEx.ConnectionTest do
         name: name,
         timeout: 1_000,
         transport: {DummyTransport, transport_name},
-        js_logger: nil,
+        js_logger: js_logger,
         pg_scope: scope
       )
-
-    Connection.handle_playwright_msg(name, %{method: :__create__, params: %{guid: "Playwright", initializer: %{}}})
-
-    assert_eventually(fn ->
-      match?({:started, _}, :sys.get_state(name))
-    end)
 
     name
   end

--- a/test/playwright_ex/processes/frame_event_recorder_test.exs
+++ b/test/playwright_ex/processes/frame_event_recorder_test.exs
@@ -126,24 +126,36 @@ defmodule PlaywrightEx.FrameEventRecorderTest do
         pg_scope: scope
       )
 
-    Connection.handle_playwright_msg(connection, %{method: :__create__, params: %{guid: "Playwright", initializer: %{}}})
+    {:pending, data} = :sys.get_state(connection)
+    Connection.handle_playwright_msg(connection, %{id: data.initialization.id, result: %{}})
+
+    Connection.handle_playwright_msg(connection, %{
+      guid: "",
+      method: :__create__,
+      params: %{type: "Playwright", guid: "Playwright", initializer: %{}}
+    })
 
     assert_eventually(fn ->
       match?({:started, _}, :sys.get_state(connection))
     end)
 
     Connection.handle_playwright_msg(connection, %{
+      guid: "context-1",
       method: :__create__,
-      params: %{guid: page_id, initializer: %{main_frame: %{guid: frame_id}}}
+      params: %{
+        type: "Frame",
+        guid: frame_id,
+        initializer: %{url: "about:blank", load_states: ["commit"]}
+      }
     })
 
     Connection.handle_playwright_msg(connection, %{
+      guid: "context-1",
       method: :__create__,
-      params: %{
-        guid: frame_id,
-        initializer: %{url: "about:blank", load_states: ["commit"], page: %{guid: page_id}}
-      }
+      params: %{type: "Page", guid: page_id, initializer: %{main_frame: %{guid: frame_id}}}
     })
+
+    Connection.handle_playwright_msg(connection, %{guid: page_id, method: :__adopt__, params: %{guid: frame_id}})
 
     assert_eventually(fn ->
       case safe_initializer(connection, frame_id) do

--- a/test/playwright_ex/processes/port_transport_test.exs
+++ b/test/playwright_ex/processes/port_transport_test.exs
@@ -15,4 +15,33 @@ defmodule PlaywrightEx.PortTransportTest do
                    PortTransport.start_link(executable: executable)
                  end
   end
+
+  test "buffers fragmented one-to-three-byte frame headers" do
+    json = JSON.encode!(%{id: 7, result: %{}})
+    frame = <<byte_size(json)::unsigned-little-integer-size(32), json::binary>>
+    state = %PortTransport{port: :fake_port, connection_name: self()}
+
+    <<first::binary-size(1), second::binary-size(2), rest::binary>> = frame
+    assert {:noreply, state} = PortTransport.handle_info({:fake_port, {:data, first}}, state)
+    refute_receive {:"$gen_cast", _}
+
+    assert {:noreply, state} = PortTransport.handle_info({:fake_port, {:data, second}}, state)
+    refute_receive {:"$gen_cast", _}
+
+    assert {:noreply, _state} = PortTransport.handle_info({:fake_port, {:data, rest}}, state)
+    assert_receive {:"$gen_cast", {:playwright_msg, %{id: 7, result: %{}}}}
+  end
+
+  test "parses multiple frames from one port message" do
+    frames =
+      for id <- [1, 2] do
+        json = JSON.encode!(%{id: id, result: %{}})
+        <<byte_size(json)::unsigned-little-integer-size(32), json::binary>>
+      end
+
+    state = %PortTransport{port: :fake_port, connection_name: self()}
+    assert {:noreply, _state} = PortTransport.handle_info({:fake_port, {:data, IO.iodata_to_binary(frames)}}, state)
+    assert_receive {:"$gen_cast", {:playwright_msg, %{id: 1}}}
+    assert_receive {:"$gen_cast", {:playwright_msg, %{id: 2}}}
+  end
 end

--- a/test/playwright_ex/processes/websocket_transport_test.exs
+++ b/test/playwright_ex/processes/websocket_transport_test.exs
@@ -1,0 +1,13 @@
+if Code.ensure_loaded?(WebSockex) do
+  defmodule PlaywrightEx.WebSocketTransportTest do
+    use ExUnit.Case, async: true
+
+    alias PlaywrightEx.WebSocketTransport
+
+    test "disconnect terminates the transport so rest_for_one rebuilds connection state" do
+      state = %WebSocketTransport{ws_endpoint: "ws://localhost:3000", connection_name: :connection}
+
+      assert {:ok, ^state} = WebSocketTransport.handle_disconnect(%{}, state)
+    end
+  end
+end

--- a/test/playwright_ex/tracing_test.exs
+++ b/test/playwright_ex/tracing_test.exs
@@ -33,6 +33,23 @@ defmodule PlaywrightEx.TracingTest do
     end
   end
 
+  describe "tracing_stop_chunk/2 modes" do
+    test "handles discard results without an artifact", %{tracing_id: tracing_id} do
+      {:ok, _} = Tracing.tracing_start(tracing_id, timeout: @timeout)
+      {:ok, _} = Tracing.tracing_start_chunk(tracing_id, timeout: @timeout)
+      assert {:ok, nil} = Tracing.tracing_stop_chunk(tracing_id, mode: :discard, timeout: @timeout)
+      assert {:ok, _} = Tracing.tracing_stop(tracing_id, timeout: @timeout)
+    end
+
+    test "returns entries in entries mode", %{tracing_id: tracing_id} do
+      {:ok, _} = Tracing.tracing_start(tracing_id, timeout: @timeout)
+      {:ok, _} = Tracing.tracing_start_chunk(tracing_id, timeout: @timeout)
+      assert {:ok, entries} = Tracing.tracing_stop_chunk(tracing_id, mode: :entries, timeout: @timeout)
+      assert is_list(entries)
+      assert {:ok, _} = Tracing.tracing_stop(tracing_id, timeout: @timeout)
+    end
+  end
+
   describe "group/3" do
     test "writes name and location with nesting", %{tracing_id: tracing_id, frame: frame} do
       start_tracing(tracing_id)

--- a/test/playwright_ex_test.exs
+++ b/test/playwright_ex_test.exs
@@ -41,6 +41,19 @@ defmodule PlaywrightExTest do
     assert_has(frame.guid, Selector.link("macOS"))
   end
 
+  test "launches with Playwright 1.63 environment and signal fields" do
+    assert {:ok, browser} =
+             PlaywrightEx.launch_browser(:chromium,
+               env: %{"PLAYWRIGHT_EX_PROTOCOL_TEST" => "1"},
+               handle_sigint: false,
+               handle_sigterm: false,
+               handle_sighup: false,
+               timeout: @timeout
+             )
+
+    assert {:ok, _} = PlaywrightEx.Browser.close(browser.guid, timeout: @timeout)
+  end
+
   def on_exit_open_trace(tracing_id, tmp_dir, timeout) do
     {:ok, _} =
       Tracing.tracing_start(tracing_id,


### PR DESCRIPTION
## Summary

- align all implemented channel parameters, enums, optional results, and serialized values with the Playwright 1.63 protocol
- track create/adopt ownership and recursive disposal so frame waiters follow page close and crash events correctly
- fix fragmented port framing, WebSocket version negotiation and reconnect lifecycle, error logs, and remote artifact cleanup
- document the full compatibility sweep in the changelog

## Testing

- mix check (153 tests, Credo, warnings-as-errors compilation, Dialyzer)
- WebSocket disconnect behavior has unit coverage
- containerized WebSocket integration was not run because the Docker daemon is unavailable on this host